### PR TITLE
Auto-publish loom3 1.0.5 from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,21 @@
 name: Publish to NPM
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version bump type (patch, minor, major) or skip to use current version'
-        required: false
-        default: 'skip'
-        type: choice
-        options:
-          - skip
-          - patch
-          - minor
-          - major
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - name: Checkout
@@ -30,8 +24,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -41,6 +35,15 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Read package metadata
+        id: pkg
+        run: |
+          echo "name=$(node -p \"require('./package.json').name\")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
 
       - name: Verify NPM auth
         run: |
@@ -53,16 +56,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}
 
-      - name: Bump version
-        if: github.event.inputs.version != 'skip' && github.event.inputs.version != ''
+      - name: Check if version already exists on NPM
+        id: existing
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ github.event.inputs.version }} -m "Bump version to %s"
-          git push --follow-tags
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.pkg.outputs.version }} is already published."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.pkg.outputs.version }} is not published yet."
+          fi
 
       - name: Publish to NPM
-        run: |
-          npm publish --access public
+        if: steps.existing.outputs.exists != 'true'
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loom3",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loom3",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/three": "^0.170.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lovelace_lol/loom3",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Lightweight 3D character animation engine for facial AUs, visemes, and bone-driven motion",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump `@lovelace_lol/loom3` from `1.0.4` to `1.0.5`
- change npm publishing to run on `push` to `main` instead of release/manual version bumping
- publish only when the committed `package.json` version is not already present on npm
- keep `workflow_dispatch` as a manual retry path for the current committed version

## Testing
- `npm ci`
- `npm test`
- `npm run build`
- `npm run typecheck`

## Follow-up
- after this merges and npm publishes `1.0.5`, update LoomLarge to consume the published version instead of a git ref or older package version
