### PR TITLE
ci: fix loom3 publish metadata step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Read package metadata
         id: pkg
         run: |
-          echo "name=$(node -p \"require('./package.json').name\")" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+          echo "name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
 
       - name: Verify NPM auth
         run: |


### PR DESCRIPTION
## Summary
- fix shell quoting in the publish workflow when reading package metadata
- unblock automatic npm publishing from main

## Testing
- workflow logic only
