### PR TITLE
CI: update publish workflow to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- upgrade the publish workflow to Node 24-compatible GitHub Actions
- run the Loom3 publish job itself on Node 24
- remove the Node 20 deprecation warning ahead of the June 2, 2026 runner change

## Validation
- reviewed the workflow diff locally
- confirmed Loom3 only has this single workflow path to update