### PR TITLE
CI: align Loom3 publish workflow with npm metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "24"
+          cache: "npm"
 
       - name: Configure git author
         run: |
@@ -64,6 +65,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "24"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
   "homepage": "https://github.com/meekmachine/Loom3#readme",
   "author": "Jonathan",
   "license": "MIT",
-  "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a"
+  "packageManager": "npm@10.9.2"
 }


### PR DESCRIPTION
## Summary
- fix the merged publish workflow's package-manager mismatch
- declare Loom3 as an npm-managed package instead of pnpm in package.json
- set explicit npm caching in setup-node so the workflow does not try to locate pnpm

## Why
The auto-version-bump workflow merged successfully, but  detected the stale  field and attempted pnpm-specific setup. This repo actually uses  and .

## Validation
- validated workflow YAML locally
- confirmed packageManager now matches the actual repo tooling