### PR TITLE
ci: add Loom3 pull request checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,49 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - name: Build
+            command: npm run build
+          - name: Typecheck
+            command: npm run typecheck
+          - name: Test
+            command: npm test
+    name: ${{ matrix.check.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ${{ matrix.check.name }}
+        run: ${{ matrix.check.command }}


### PR DESCRIPTION
## Summary
- add a dedicated pull request workflow for Loom3
- run the existing build, typecheck, and test scripts on PRs targeting main
- cancel superseded PR runs so the latest push is the one that finishes

## Testing
- npm ci
- npm run build
- npm run typecheck
- npm test