### PR TITLE
ci: fix publish tag creation identity regression

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           ref: "${{ github.event_name == 'workflow_dispatch' && github.sha || needs.prepare_release.outputs.release_sha }}"
 
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
- configure the git author in the publish job before annotated tag creation
- reuse the same github-actions identity already used by prepare_release
- keep the release-sync logic from PR #49 intact while unblocking tag/release creation

## Why
Recent `Publish to NPM` runs on `main` started failing on March 25, 2026 in the `Create release tag` step because the publish job creates an annotated tag without a configured git identity.

## Verification
- ruby YAML parse of `.github/workflows/publish.yml`
- `git diff --check`

## Follow-up
After merge, rerun one of the failed `Publish to NPM` jobs or merge a trivial PR to confirm the tag + release path succeeds.