### PR TITLE
feat: add explicit canonical viseme bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,30 @@ import { CC4_PRESET } from '@lovelace_lol/loom3';
     'TONGUE': 'CC_Base_Tongue01',
   },
 
+  visemeBindings: {
+    // Canonical 15-slot viseme bindings for lip-sync
+    EE: { morph: 'V_EE', jawAmount: 0.20 },
+    Ah: { morph: 'V_Ah', jawAmount: 0.80 },
+    Oh: { morph: 'V_Oh', jawAmount: 0.60 },
+    OO: { morph: 'V_OO', jawAmount: 0.50 },
+    I: { morph: 'V_I', jawAmount: 0.20 },
+    U: { morph: 'V_U', jawAmount: 0.50 },
+    W: { morph: 'V_W', jawAmount: 0.40 },
+    L: { morph: 'V_L', jawAmount: 0.30 },
+    F_V: { morph: 'V_F_V', jawAmount: 0.10 },
+    Th: { morph: 'V_Th', jawAmount: 0.15 },
+    S_Z: { morph: 'V_S_Z', jawAmount: 0.10 },
+    B_M_P: { morph: 'V_B_M_P', jawAmount: 0.00 },
+    K_G_H_NG: { morph: 'V_K_G_H_NG', jawAmount: 0.35 },
+    AE: { morph: 'V_AE', jawAmount: 0.75 },
+    R: { morph: 'V_R', jawAmount: 0.35 },
+  },
+
   visemeKeys: [
-    // 15 viseme morph names for lip-sync
-    'V_EE', 'V_Er', 'V_IH', 'V_Ah', 'V_Oh',
-    'V_W_OO', 'V_S_Z', 'V_Ch_J', 'V_F_V', 'V_TH',
-    'V_T_L_D_N', 'V_B_M_P', 'V_K_G_H_NG', 'V_AE', 'V_R'
+    // Legacy compiled array for indexed playback
+    'V_EE', 'V_Ah', 'V_Oh', 'V_OO', 'V_I',
+    'V_U', 'V_W', 'V_L', 'V_F_V', 'V_Th',
+    'V_S_Z', 'V_B_M_P', 'V_K_G_H_NG', 'V_AE', 'V_R'
   ],
 
   morphToMesh: {
@@ -1078,29 +1097,31 @@ Visemes are mouth shapes used for lip-sync. Loom3 includes 15 visemes with autom
 | Index | Key | Phoneme Example |
 |-------|-----|-----------------|
 | 0 | EE | "b**ee**" |
-| 1 | Er | "h**er**" |
-| 2 | IH | "s**i**t" |
-| 3 | Ah | "f**a**ther" |
-| 4 | Oh | "g**o**" |
-| 5 | W_OO | "t**oo**" |
-| 6 | S_Z | "**s**un, **z**oo" |
-| 7 | Ch_J | "**ch**ip, **j**ump" |
+| 1 | Ah | "f**a**ther" |
+| 2 | Oh | "g**o**" |
+| 3 | OO | "t**oo**" |
+| 4 | I | "s**i**t" |
+| 5 | U | "b**oo**t" |
+| 6 | W | "**w**in" |
+| 7 | L | "yo**l**k" |
 | 8 | F_V | "**f**un, **v**an" |
-| 9 | TH | "**th**ink" |
-| 10 | T_L_D_N | "**t**op, **l**ip, **d**og, **n**o" |
+| 9 | Th | "**th**ink" |
+| 10 | S_Z | "**s**un, **z**oo" |
 | 11 | B_M_P | "**b**at, **m**an, **p**op" |
 | 12 | K_G_H_NG | "**k**ite, **g**o, **h**at, si**ng**" |
 | 13 | AE | "c**a**t" |
 | 14 | R | "**r**ed" |
 
+`visemeBindings` is the authored contract. `visemeKeys` is the compiled runtime array and should preserve these slots in order.
+
 ### Setting a viseme
 
 ```typescript
-// Set viseme 3 (Ah) to full intensity
-loom.setViseme(3, 1.0);
+// Set viseme 1 (Ah) to full intensity
+loom.setViseme(1, 1.0);
 
 // With jaw scale (0-1, default 1)
-loom.setViseme(3, 1.0, 0.5);  // Half jaw opening
+loom.setViseme(1, 1.0, 0.5);  // Half jaw opening
 ```
 
 ### Transitioning visemes
@@ -1109,10 +1130,10 @@ Viseme transitions default to 80ms and use the standard `easeInOutQuad` easing w
 
 ```typescript
 // Animate to a viseme using the default 80ms duration
-const handle = loom.transitionViseme(3, 1.0);
+const handle = loom.transitionViseme(1, 1.0);
 
 // Disable jaw coupling (duration can be omitted to use the 80ms default)
-loom.transitionViseme(3, 1.0, 80, 0);
+loom.transitionViseme(1, 1.0, 80, 0);
 ```
 
 ### Automatic jaw coupling
@@ -1121,10 +1142,21 @@ Each viseme has a predefined jaw opening amount. When you set a viseme, the jaw 
 
 | Viseme | Jaw Amount |
 |--------|------------|
-| EE | 0.15 |
-| Ah | 0.70 |
-| Oh | 0.50 |
-| B_M_P | 0.20 |
+| EE | 0.20 |
+| Ah | 0.80 |
+| Oh | 0.60 |
+| OO | 0.50 |
+| I | 0.20 |
+| U | 0.50 |
+| W | 0.40 |
+| L | 0.30 |
+| F_V | 0.10 |
+| Th | 0.15 |
+| S_Z | 0.10 |
+| B_M_P | 0.00 |
+| K_G_H_NG | 0.35 |
+| AE | 0.75 |
+| R | 0.35 |
 
 The `jawScale` parameter multiplies this amount:
 - `jawScale = 1.0`: Normal jaw opening

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
 import type { Profile } from '../../mappings/types';
+import { compileVisemeJawAmounts, compileVisemeKeys } from '../../mappings/visemes';
 import type { ResolvedBones } from './types';
 import { getSideScale, resolveCurveBalance } from './balanceUtils';
 
@@ -521,13 +522,15 @@ export class BakedAnimationController {
     const globalBalance = options?.balance ?? 0;
     const balanceMap = options?.balanceMap;
     const meshNames = options?.meshNames;
+    const visemeKeys = compileVisemeKeys(config.visemeBindings, config.visemeKeys || [], config.visemeJawAmounts || []);
+    const visemeJawAmounts = compileVisemeJawAmounts(config.visemeBindings, config.visemeKeys || [], config.visemeJawAmounts || []);
     let maxTime = 0;
 
     const isNumericAU = (id: string) => /^\d+$/.test(id);
     const isVisemeIndex = (id: string) => {
       if (options?.snippetCategory !== 'visemeSnippet') return false;
       const num = Number(id);
-      return !Number.isNaN(num) && num >= 0 && num < config.visemeKeys.length;
+      return !Number.isNaN(num) && num >= 0 && num < visemeKeys.length;
     };
 
     const sampleAt = (arr: Array<{ time: number; intensity: number }>, t: number) => {
@@ -572,7 +575,7 @@ export class BakedAnimationController {
 
         if (isVisemeIndex(curveId)) {
           const visemeMeshNames = this.getMeshNamesForViseme(config, meshNames);
-          const visemeKey = config.visemeKeys[auId];
+          const visemeKey = visemeKeys[auId];
           if (typeof visemeKey === 'number') {
             this.addMorphIndexTracks(tracks, visemeKey, keyframes, intensityScale, visemeMeshNames);
           } else if (visemeKey) {
@@ -625,8 +628,6 @@ export class BakedAnimationController {
     // This replicates transitionViseme behavior for clip-based playback
     const autoVisemeJaw = options?.autoVisemeJaw !== false; // Default true
     const jawScale = options?.jawScale ?? 1.0;
-    const visemeJawAmounts = config.visemeJawAmounts;
-
     if (
       autoVisemeJaw &&
       jawScale > 0 &&
@@ -645,7 +646,7 @@ export class BakedAnimationController {
           let jawAmount = 0;
 
           // Sum contributions from all active visemes at time t
-          for (let visemeIdx = 0; visemeIdx < config.visemeKeys.length; visemeIdx++) {
+          for (let visemeIdx = 0; visemeIdx < visemeKeys.length; visemeIdx++) {
             const visemeCurve = curves[String(visemeIdx)];
             if (!visemeCurve) continue;
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -41,6 +41,7 @@ import { HairPhysicsController, type HairPhysicsConfig, type HairPhysicsConfigUp
 import { CC4_PRESET, CC4_MESHES, COMPOSITE_ROTATIONS as CC4_COMPOSITE_ROTATIONS } from '../../presets/cc4';
 import { resolvePreset } from '../../presets';
 import { resolveProfile } from '../../mappings/resolveProfile';
+import { CANONICAL_VISEME_JAW_AMOUNTS, compileVisemeJawAmounts, compileVisemeKeys } from '../../mappings/visemes';
 import type { NodeBase, ResolvedBones } from './types';
 
 const deg2rad = (d: number) => (d * Math.PI) / 180;
@@ -133,20 +134,15 @@ export class Loom3 implements LoomLarge {
   private morphIndexCache = new Map<string, MorphTargetHandle[]>();
   private resolvedAUMorphTargets = new Map<number, ResolvedMorphTargetsBySide>();
   private resolvedVisemeTargets: MorphTargetHandle[][] = [];
+  private visemeKeys: Array<MorphTargetRef | undefined> = [];
+  private visemeJawAmounts: number[] = [];
 
   // Bones
   private bones: ResolvedBones = {};
   private mixWeights: Record<number, number> = {};
 
   // Viseme state
-  private visemeValues: number[] = new Array(15).fill(0);
-
-
-  // Viseme jaw amounts
-  private static readonly VISEME_JAW_AMOUNTS: number[] = [
-    0.15, 0.35, 0.25, 0.70, 0.55, 0.30, 0.10, 0.20, 0.08,
-    0.12, 0.18, 0.02, 0.25, 0.60, 0.40,
-  ];
+  private visemeValues: number[] = [];
 
   private bakedAnimations: BakedAnimationController;
   private hairPhysics: HairPhysicsController;
@@ -174,6 +170,17 @@ export class Loom3 implements LoomLarge {
   ) {
     const basePreset = config.presetType ? resolvePreset(config.presetType) : CC4_PRESET;
     this.config = config.profile ? resolveProfile(basePreset, config.profile) : basePreset;
+    this.visemeKeys = compileVisemeKeys(
+      this.config.visemeBindings,
+      this.config.visemeKeys || [],
+      this.config.visemeJawAmounts || []
+    );
+    this.visemeJawAmounts = compileVisemeJawAmounts(
+      this.config.visemeBindings,
+      this.config.visemeKeys || [],
+      this.config.visemeJawAmounts || []
+    );
+    this.visemeValues = new Array(this.visemeKeys.length).fill(0);
     this.mixWeights = { ...this.config.auMixDefaults };
     this.animation = animation || new AnimationThree();
 
@@ -324,12 +331,14 @@ export class Loom3 implements LoomLarge {
       this.resolvedAUMorphTargets.set(auId, resolved);
     }
 
-    for (let i = 0; i < (this.config.visemeKeys || []).length; i += 1) {
-      const key = this.config.visemeKeys[i];
+    for (let i = 0; i < this.visemeKeys.length; i += 1) {
+      const key = this.visemeKeys[i];
       const visemeMeshNames = this.getMeshNamesForViseme();
       const targets = typeof key === 'number'
         ? this.resolveMorphTargetsByIndex(key, visemeMeshNames)
-        : this.resolveMorphTargets(key, visemeMeshNames);
+        : typeof key === 'string'
+          ? this.resolveMorphTargets(key, visemeMeshNames)
+          : [];
       this.resolvedVisemeTargets[i] = targets;
     }
   }
@@ -855,7 +864,7 @@ export class Loom3 implements LoomLarge {
   // ============================================================================
 
   setViseme(visemeIndex: number, value: number, jawScale = 1.0): void {
-    if (visemeIndex < 0 || visemeIndex >= this.config.visemeKeys.length) return;
+    if (visemeIndex < 0 || visemeIndex >= this.visemeKeys.length) return;
 
     const val = clamp01(value);
     this.visemeValues[visemeIndex] = val;
@@ -864,7 +873,7 @@ export class Loom3 implements LoomLarge {
     if (targets && targets.length > 0) {
       this.applyMorphTargets(targets, val);
     } else {
-      const morphKey = this.config.visemeKeys[visemeIndex];
+      const morphKey = this.visemeKeys[visemeIndex];
       const visemeMeshNames = this.getMeshNamesForViseme();
       if (typeof morphKey === 'number') {
         this.setMorphInfluence(morphKey, val, visemeMeshNames);
@@ -873,33 +882,36 @@ export class Loom3 implements LoomLarge {
       }
     }
 
-    const jawAmount = Loom3.VISEME_JAW_AMOUNTS[visemeIndex] * val * jawScale;
+    const jawAmount = (this.visemeJawAmounts[visemeIndex] ?? CANONICAL_VISEME_JAW_AMOUNTS[visemeIndex] ?? 0) * val * jawScale;
     if (Math.abs(jawScale) > 1e-6 && Math.abs(jawAmount) > 1e-6) {
       this.updateBoneRotation('JAW', 'pitch', jawAmount);
     }
   }
 
   transitionViseme(visemeIndex: number, to: number, durationMs = 80, jawScale = 1.0): TransitionHandle {
-    if (visemeIndex < 0 || visemeIndex >= this.config.visemeKeys.length) {
+    if (visemeIndex < 0 || visemeIndex >= this.visemeKeys.length) {
       return { promise: Promise.resolve(), pause: () => {}, resume: () => {}, cancel: () => {} };
     }
 
-    const morphKey = this.config.visemeKeys[visemeIndex];
+    const morphKey = this.visemeKeys[visemeIndex];
     const target = clamp01(to);
     this.visemeValues[visemeIndex] = target;
     const visemeMeshNames = this.getMeshNamesForViseme();
+    const handles: TransitionHandle[] = [];
+    if (typeof morphKey === 'number') {
+      handles.push(this.transitionMorphInfluence(morphKey, target, durationMs, visemeMeshNames));
+    } else if (typeof morphKey === 'string') {
+      handles.push(this.transitionMorph(morphKey, target, durationMs, visemeMeshNames));
+    }
 
-    const morphHandle = typeof morphKey === 'number'
-      ? this.transitionMorphInfluence(morphKey, target, durationMs, visemeMeshNames)
-      : this.transitionMorph(morphKey, target, durationMs, visemeMeshNames);
-
-    const jawAmount = Loom3.VISEME_JAW_AMOUNTS[visemeIndex] * target * jawScale;
+    const jawAmount = (this.visemeJawAmounts[visemeIndex] ?? CANONICAL_VISEME_JAW_AMOUNTS[visemeIndex] ?? 0) * target * jawScale;
     if (Math.abs(jawScale) <= 1e-6 || Math.abs(jawAmount) <= 1e-6) {
-      return morphHandle;
+      return this.combineHandles(handles);
     }
 
     const jawHandle = this.transitionBoneRotation('JAW', 'pitch', jawAmount, durationMs);
-    return this.combineHandles([morphHandle, jawHandle]);
+    handles.push(jawHandle);
+    return this.combineHandles(handles);
   }
 
   // ============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export {
   CC4_SUFFIX_PATTERN,
   CC4_EYE_MESH_NODES,
   CC4_MESHES,
+  VISEME_BINDINGS,
   VISEME_KEYS,
   VISEME_JAW_AMOUNTS,
   MORPH_TO_MESH,
@@ -176,6 +177,23 @@ export {
   isMixedAU,
   hasLeftRightMorphs,
 } from './presets/cc4';
+export {
+  CANONICAL_VISEME_IDS,
+  CANONICAL_VISEME_INDEX_BY_ID,
+  CANONICAL_VISEME_JAW_AMOUNTS,
+  compileVisemeJawAmounts,
+  compileVisemeKeys,
+  createVisemeBindingsFromKeys,
+  getCanonicalVisemeId,
+  getCanonicalVisemeIndex,
+  isCanonicalVisemeId,
+  resolveVisemeBindings,
+} from './mappings/visemes';
+export type {
+  CanonicalVisemeId,
+  VisemeBinding,
+  VisemeBindings,
+} from './mappings/visemes';
 
 // Fish/skeletal preset
 export { BETTA_FISH_PRESET, AU_MAPPING_CONFIG as FISH_AU_MAPPING_CONFIG } from './presets/bettaFish';

--- a/src/mappings/resolveProfile.test.ts
+++ b/src/mappings/resolveProfile.test.ts
@@ -69,4 +69,21 @@ describe('resolveProfile', () => {
       Tongue: 'tongue',
     });
   });
+
+  it('compiles legacy viseme arrays from explicit viseme bindings while preserving canonical slots', () => {
+    const result = resolveProfile(basePreset, {
+      visemeBindings: {
+        EE: { morph: 'viseme_ee', jawAmount: 0.2 },
+        Ah: { morph: 'viseme_ah', jawAmount: 0.8 },
+      },
+    });
+
+    expect(result.visemeBindings?.EE?.morph).toBe('viseme_ee');
+    expect(result.visemeKeys).toHaveLength(15);
+    expect(result.visemeKeys?.[0]).toBe('viseme_ee');
+    expect(result.visemeKeys?.[1]).toBe('viseme_ah');
+    expect(result.visemeKeys?.[2]).toBeUndefined();
+    expect(result.visemeJawAmounts?.[0]).toBeCloseTo(0.2, 2);
+    expect(result.visemeJawAmounts?.[1]).toBeCloseTo(0.8, 2);
+  });
 });

--- a/src/mappings/resolveProfile.ts
+++ b/src/mappings/resolveProfile.ts
@@ -1,5 +1,10 @@
 import type { Profile, AnnotationRegion, MorphTargetsBySide, HairPhysicsProfileConfig } from './types';
 import type { BoneBinding } from '../core/types';
+import {
+  compileVisemeJawAmounts,
+  compileVisemeKeys,
+  type VisemeBindings,
+} from './visemes';
 
 type RecordValue = string | number | boolean | object | null | undefined;
 type RecordKey = string | number;
@@ -136,6 +141,14 @@ const mergeHairPhysicsConfig = (
   return merged;
 };
 
+const mergeVisemeBindings = (
+  base?: VisemeBindings,
+  override?: VisemeBindings
+): VisemeBindings | undefined => {
+  if (!base && !override) return undefined;
+  return mergeRecord(base || {}, override || {}) as VisemeBindings;
+};
+
 /**
  * Merge a base preset with a profile override.
  *
@@ -146,6 +159,18 @@ const mergeHairPhysicsConfig = (
  * - annotationRegions: merged by region name, shallow field merge (override wins).
  */
 export function resolveProfile(base: Profile, override: Partial<Profile>): Profile {
+  const visemeBindings = mergeVisemeBindings(base.visemeBindings, override.visemeBindings);
+  const visemeKeys = override.visemeKeys
+    ? [...override.visemeKeys]
+    : visemeBindings
+      ? compileVisemeKeys(visemeBindings, base.visemeKeys || [], override.visemeJawAmounts || base.visemeJawAmounts || [])
+      : [...(base.visemeKeys || [])];
+  const visemeJawAmounts = override.visemeJawAmounts
+    ? [...override.visemeJawAmounts]
+    : visemeBindings
+      ? compileVisemeJawAmounts(visemeBindings, base.visemeKeys || [], base.visemeJawAmounts || [])
+      : [...(base.visemeJawAmounts || [])];
+
   return {
     ...base,
     ...override,
@@ -156,8 +181,10 @@ export function resolveProfile(base: Profile, override: Partial<Profile>): Profi
     auFacePartToMeshCategory: base.auFacePartToMeshCategory || override.auFacePartToMeshCategory
       ? mergeRecord(base.auFacePartToMeshCategory || {}, override.auFacePartToMeshCategory || {}) as Record<string, string>
       : undefined,
-    visemeKeys: override.visemeKeys ? [...override.visemeKeys] : [...base.visemeKeys],
+    visemeBindings,
+    visemeKeys,
     visemeMeshCategory: override.visemeMeshCategory ?? base.visemeMeshCategory,
+    visemeJawAmounts,
     auMixDefaults: base.auMixDefaults || override.auMixDefaults
       ? mergeRecord(base.auMixDefaults || {}, override.auMixDefaults || {})
       : undefined,

--- a/src/mappings/types.ts
+++ b/src/mappings/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BoneBinding, AUInfo, CompositeRotation } from '../core/types';
+import type { VisemeBindings } from './visemes';
 
 /**
  * Profile - Complete configuration for AU-to-morph/bone mappings
@@ -88,8 +89,15 @@ export interface Profile {
    */
   auFacePartToMeshCategory?: Record<string, string>;
 
-  /** Viseme targets in order (typically 15 phoneme positions) */
-  visemeKeys: MorphTargetRef[];
+  /**
+   * Canonical viseme bindings keyed by named viseme slot.
+   * When present, this is the authored source of truth. Legacy `visemeKeys`
+   * arrays are still accepted and compiled at the engine boundary.
+   */
+  visemeBindings?: VisemeBindings;
+
+  /** Legacy positional viseme targets, compiled from canonical bindings when available. */
+  visemeKeys?: Array<MorphTargetRef | undefined>;
 
   /**
    * Optional `morphToMesh` category to use for viseme morph routing.
@@ -97,7 +105,7 @@ export interface Profile {
    */
   visemeMeshCategory?: string;
 
-  /** Optional: Jaw opening amounts per viseme index (0-1). Used for auto-generating jaw rotation in clips. */
+  /** Optional: Jaw opening amounts per viseme slot (0-1). Used for auto-generating jaw rotation in clips. */
   visemeJawAmounts?: number[];
 
   /** Optional: Default mix weights for bone/morph blending (0 = morph only, 1 = bone only) */

--- a/src/mappings/visemes.test.ts
+++ b/src/mappings/visemes.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_VISEME_IDS,
+  CANONICAL_VISEME_JAW_AMOUNTS,
+  compileVisemeJawAmounts,
+  compileVisemeKeys,
+  createVisemeBindingsFromKeys,
+  resolveVisemeBindings,
+} from './visemes';
+
+describe('viseme helpers', () => {
+  it('keeps the canonical 15-slot order even when bindings are sparse', () => {
+    const bindings = {
+      EE: { morph: 'viseme_ee', jawAmount: 0.2 },
+      Ah: { morph: 'viseme_ah', jawAmount: 0.8 },
+      R: { morph: 'viseme_r', jawAmount: 0.35 },
+    };
+
+    const compiledKeys = compileVisemeKeys(bindings, [], []);
+    const compiledJawAmounts = compileVisemeJawAmounts(bindings, [], []);
+
+    expect(CANONICAL_VISEME_IDS).toHaveLength(15);
+    expect(compiledKeys).toHaveLength(15);
+    expect(compiledJawAmounts).toHaveLength(15);
+    expect(compiledKeys[0]).toBe('viseme_ee');
+    expect(compiledKeys[1]).toBe('viseme_ah');
+    expect(compiledKeys[2]).toBeUndefined();
+    expect(compiledKeys[14]).toBe('viseme_r');
+    expect(compiledJawAmounts[2]).toBeCloseTo(CANONICAL_VISEME_JAW_AMOUNTS[2], 2);
+  });
+
+  it('round-trips a compiled legacy array into explicit bindings', () => {
+    const legacy = [
+      'viseme_ee',
+      'viseme_ah',
+      undefined,
+      'viseme_oo',
+    ];
+
+    const bindings = createVisemeBindingsFromKeys(legacy);
+    const resolved = resolveVisemeBindings(bindings, legacy, []);
+
+    expect(bindings.EE?.morph).toBe('viseme_ee');
+    expect(bindings.Ah?.morph).toBe('viseme_ah');
+    expect(resolved[0].morph).toBe('viseme_ee');
+    expect(resolved[2].morph).toBeUndefined();
+    expect(resolved).toHaveLength(15);
+  });
+});

--- a/src/mappings/visemes.ts
+++ b/src/mappings/visemes.ts
@@ -1,0 +1,148 @@
+/**
+ * Loom3 - Canonical viseme contract.
+ *
+ * This module defines the canonical viseme IDs used by Loom3 profiles and
+ * provides helpers for converting between named bindings and the legacy
+ * positional array representation.
+ */
+
+export const CANONICAL_VISEME_IDS = [
+  'EE',
+  'Ah',
+  'Oh',
+  'OO',
+  'I',
+  'U',
+  'W',
+  'L',
+  'F_V',
+  'Th',
+  'S_Z',
+  'B_M_P',
+  'K_G_H_NG',
+  'AE',
+  'R',
+] as const;
+
+export type CanonicalVisemeId = (typeof CANONICAL_VISEME_IDS)[number];
+
+export const CANONICAL_VISEME_INDEX_BY_ID: Record<CanonicalVisemeId, number> =
+  Object.fromEntries(CANONICAL_VISEME_IDS.map((id, index) => [id, index])) as Record<CanonicalVisemeId, number>;
+
+export const getCanonicalVisemeIndex = (id: CanonicalVisemeId): number => CANONICAL_VISEME_INDEX_BY_ID[id];
+
+export const getCanonicalVisemeId = (index: number): CanonicalVisemeId | undefined => CANONICAL_VISEME_IDS[index];
+
+export const CANONICAL_VISEME_JAW_AMOUNTS: number[] = [
+  0.20,
+  0.80,
+  0.60,
+  0.50,
+  0.20,
+  0.50,
+  0.40,
+  0.30,
+  0.10,
+  0.15,
+  0.10,
+  0.00,
+  0.35,
+  0.75,
+  0.35,
+];
+
+export type VisemeMorphTargetRef = string | number | undefined;
+
+export interface VisemeBinding {
+  morph: VisemeMorphTargetRef;
+  jawAmount?: number;
+  note?: string;
+  sharedWith?: CanonicalVisemeId[];
+}
+
+export type VisemeBindings = Partial<Record<CanonicalVisemeId, VisemeBinding>>;
+
+export interface ResolvedVisemeBinding {
+  id: CanonicalVisemeId;
+  morph: VisemeMorphTargetRef;
+  jawAmount: number;
+  binding?: VisemeBinding;
+  source: 'binding' | 'legacy' | 'hybrid' | 'empty';
+}
+
+const clampVisemeId = (id: string): id is CanonicalVisemeId =>
+  (CANONICAL_VISEME_IDS as readonly string[]).includes(id);
+
+export const isCanonicalVisemeId = (value: string): value is CanonicalVisemeId => clampVisemeId(value);
+
+export function createVisemeBindingsFromKeys(
+  keys: VisemeMorphTargetRef[],
+  jawAmounts: number[] = CANONICAL_VISEME_JAW_AMOUNTS
+): VisemeBindings {
+  const bindings: VisemeBindings = {};
+  for (let i = 0; i < CANONICAL_VISEME_IDS.length; i += 1) {
+    const key = keys[i];
+    if (key === undefined) continue;
+    bindings[CANONICAL_VISEME_IDS[i]] = {
+      morph: key,
+      jawAmount: jawAmounts[i] ?? CANONICAL_VISEME_JAW_AMOUNTS[i],
+    };
+  }
+  return bindings;
+}
+
+export function resolveVisemeBindings(
+  visemeBindings?: VisemeBindings,
+  visemeKeys: VisemeMorphTargetRef[] = [],
+  visemeJawAmounts: number[] = CANONICAL_VISEME_JAW_AMOUNTS
+): ResolvedVisemeBinding[] {
+  const resolved: ResolvedVisemeBinding[] = [];
+
+  for (let i = 0; i < CANONICAL_VISEME_IDS.length; i += 1) {
+    const id = CANONICAL_VISEME_IDS[i];
+    const binding = visemeBindings?.[id];
+    const legacyMorph = visemeKeys[i];
+    const morph = binding?.morph ?? legacyMorph;
+
+    const jawAmount = binding?.jawAmount ?? visemeJawAmounts[i] ?? CANONICAL_VISEME_JAW_AMOUNTS[i] ?? 0;
+    resolved.push({
+      id,
+      morph,
+      jawAmount,
+      binding,
+      source: binding
+        ? (legacyMorph === undefined ? 'binding' : 'hybrid')
+        : (legacyMorph === undefined ? 'empty' : 'legacy'),
+    });
+  }
+
+  return resolved;
+}
+
+export function compileVisemeKeys(
+  visemeBindings?: VisemeBindings,
+  visemeKeys: VisemeMorphTargetRef[] = [],
+  visemeJawAmounts: number[] = CANONICAL_VISEME_JAW_AMOUNTS
+): VisemeMorphTargetRef[] {
+  return resolveVisemeBindings(visemeBindings, visemeKeys, visemeJawAmounts).map((entry) => entry.morph);
+}
+
+export function compileVisemeJawAmounts(
+  visemeBindings?: VisemeBindings,
+  visemeKeys: VisemeMorphTargetRef[] = [],
+  visemeJawAmounts: number[] = CANONICAL_VISEME_JAW_AMOUNTS
+): number[] {
+  return resolveVisemeBindings(visemeBindings, visemeKeys, visemeJawAmounts).map((entry) => entry.jawAmount);
+}
+
+export function visemeBindingsToMorphSet(visemeBindings?: VisemeBindings, visemeKeys: VisemeMorphTargetRef[] = []): Set<string> {
+  const morphs = new Set<string>();
+
+  for (const entry of resolveVisemeBindings(visemeBindings, visemeKeys)) {
+    if (typeof entry.morph === 'string') {
+      morphs.add(entry.morph);
+    }
+  }
+
+  return morphs;
+}

--- a/src/presets/__tests__/cc4.test.ts
+++ b/src/presets/__tests__/cc4.test.ts
@@ -4,6 +4,7 @@ import {
   BONE_AU_TO_BINDINGS,
   COMPOSITE_ROTATIONS,
   CONTINUUM_PAIRS_MAP,
+  VISEME_BINDINGS,
   VISEME_KEYS,
   isMixedAU,
   hasLeftRightMorphs,
@@ -292,8 +293,28 @@ describe('CC4 Preset', () => {
   });
 
   describe('VISEME_KEYS', () => {
-    it('should have 15 viseme keys (ARKit standard)', () => {
+    it('should have 15 viseme keys (canonical CC4 order)', () => {
       expect(VISEME_KEYS.length).toBe(15);
+    });
+
+    it('should keep the canonical CC4 slot order', () => {
+      expect(VISEME_KEYS).toEqual([
+        'EE',
+        'Ah',
+        'Oh',
+        'OO',
+        'I',
+        'U',
+        'W',
+        'L',
+        'F_V',
+        'Th',
+        'S_Z',
+        'B_M_P',
+        'K_G_H_NG',
+        'AE',
+        'R',
+      ]);
     });
 
     it('should include common visemes', () => {
@@ -302,6 +323,14 @@ describe('CC4 Preset', () => {
       expect(VISEME_KEYS).toContain('Oh');
       expect(VISEME_KEYS).toContain('B_M_P');
       expect(VISEME_KEYS).toContain('F_V');
+    });
+  });
+
+  describe('VISEME_BINDINGS', () => {
+    it('should expose explicit canonical bindings for the preset', () => {
+      expect(VISEME_BINDINGS.EE?.morph).toBe('EE');
+      expect(VISEME_BINDINGS.Ah?.jawAmount).toBeCloseTo(0.8, 2);
+      expect(VISEME_BINDINGS.B_M_P?.jawAmount).toBeCloseTo(0, 2);
     });
   });
 

--- a/src/presets/cc4.ts
+++ b/src/presets/cc4.ts
@@ -8,6 +8,11 @@
 
 import type { Profile, MeshCategory, BlendingMode, MeshMaterialSettings, MeshInfo, MorphCategory, MorphTargetsBySide } from '../mappings/types';
 import type { BoneBinding, AUInfo, CompositeRotation } from '../core/types';
+import {
+  CANONICAL_VISEME_IDS,
+  CANONICAL_VISEME_JAW_AMOUNTS,
+  createVisemeBindingsFromKeys,
+} from '../mappings/visemes';
 
 // ============================================================================
 // AU TO MORPHS - Maps AU IDs to morph target names
@@ -525,49 +530,19 @@ export const BONE_AU_TO_BINDINGS: Record<number, BoneBinding[]> = {
 };
 
 // ============================================================================
-// VISEME KEYS - CC4 viseme morph targets (15)
+// VISEME KEYS - Canonical 15-slot CC4 viseme order
 // ============================================================================
 
-export const VISEME_KEYS: string[] = [
-  'EE',
-  'Ah',
-  'Oh',
-  'OO',
-  'I',
-  'U',
-  'W',
-  'L',
-  'F_V',
-  'Th',
-  'S_Z',
-  'B_M_P',
-  'K_G_H_NG',
-  'AE',
-  'R',
-];
+export const VISEME_KEYS: string[] = [...CANONICAL_VISEME_IDS];
 
 /**
- * Jaw opening amounts for each viseme index (0-14).
+ * Jaw opening amounts for each canonical viseme slot (0-14).
  * Values are 0-1 representing how much the jaw should open.
  * Used by snippetToClip when autoVisemeJaw is enabled.
  */
-export const VISEME_JAW_AMOUNTS: number[] = [
-  0.20, // 0: EE
-  0.80, // 1: Ah
-  0.60, // 2: Oh
-  0.50, // 3: OO
-  0.20, // 4: I
-  0.50, // 5: U
-  0.40, // 6: W
-  0.30, // 7: L
-  0.10, // 8: F_V
-  0.15, // 9: Th
-  0.10, // 10: S_Z
-  0.00, // 11: B_M_P
-  0.35, // 12: K_G_H_NG
-  0.75, // 13: AE
-  0.35, // 14: R
-];
+export const VISEME_JAW_AMOUNTS: number[] = [...CANONICAL_VISEME_JAW_AMOUNTS];
+
+export const VISEME_BINDINGS = createVisemeBindingsFromKeys(VISEME_KEYS, VISEME_JAW_AMOUNTS);
 
 // ============================================================================
 // HELPER FUNCTIONS
@@ -1000,6 +975,7 @@ export const CC4_PRESET: Profile = {
   suffixPattern: CC4_SUFFIX_PATTERN,
   morphToMesh: MORPH_TO_MESH,
   auFacePartToMeshCategory: AU_FACEPART_TO_MESH_CATEGORY,
+  visemeBindings: VISEME_BINDINGS,
   visemeKeys: VISEME_KEYS,
   visemeMeshCategory: 'viseme',
   visemeJawAmounts: VISEME_JAW_AMOUNTS,

--- a/src/validation/__tests__/validateMappings.test.ts
+++ b/src/validation/__tests__/validateMappings.test.ts
@@ -112,6 +112,42 @@ describe('validateMappingConfig', () => {
     const result = validateMappingConfig(config);
     expect(result.warnings.some((issue) => issue.code === 'AU_INFO_MISSING')).toBe(true);
   });
+
+  it('does not warn on intentionally shared viseme morphs when explicitly annotated', () => {
+    const config: Profile = {
+      ...createBaseConfig(),
+      visemeBindings: {
+        EE: { morph: 'SharedSmile', sharedWith: ['Ah'] },
+        Ah: { morph: 'SharedSmile', sharedWith: ['EE'] },
+      },
+    };
+
+    const result = validateMappingConfig(config);
+    expect(result.warnings.some((issue) => issue.code === 'VISEME_SHARED_MORPH')).toBe(false);
+    expect(result.warnings.some((issue) => issue.code === 'VISEME_DUPLICATE')).toBe(false);
+  });
+
+  it('still warns when legacy viseme arrays duplicate a morph without explicit reuse metadata', () => {
+    const config: Profile = {
+      ...createBaseConfig(),
+      visemeKeys: ['SharedSmile', 'SharedSmile'],
+    };
+
+    const result = validateMappingConfig(config);
+    expect(result.warnings.some((issue) => issue.code === 'VISEME_DUPLICATE')).toBe(true);
+  });
+
+  it('accepts numeric morph refs in explicit viseme bindings', () => {
+    const config: Profile = {
+      ...createBaseConfig(),
+      visemeBindings: {
+        EE: { morph: 12 },
+      },
+    };
+
+    const result = validateMappingConfig(config);
+    expect(result.warnings.some((issue) => issue.code === 'VISEME_EMPTY')).toBe(false);
+  });
 });
 
 describe('validateMappings', () => {

--- a/src/validation/generateMappingCorrections.ts
+++ b/src/validation/generateMappingCorrections.ts
@@ -6,6 +6,13 @@
  */
 
 import type { Profile, MorphTargetsBySide, MorphTargetRef } from '../mappings/types';
+import {
+  CANONICAL_VISEME_IDS,
+  compileVisemeJawAmounts,
+  compileVisemeKeys,
+  type VisemeBindings,
+  type VisemeMorphTargetRef,
+} from '../mappings/visemes';
 import type { ValidationMorphMesh as MorphMesh, ValidationSkeleton as Skeleton } from './types';
 
 export interface MappingCorrection {
@@ -174,7 +181,9 @@ export function generateMappingCorrections(
     boneNodes: { ...config.boneNodes },
     auToMorphs: { ...config.auToMorphs },
     morphToMesh: { ...config.morphToMesh },
-    visemeKeys: [...config.visemeKeys],
+    visemeBindings: config.visemeBindings ? { ...config.visemeBindings } : undefined,
+    visemeKeys: [...(config.visemeKeys || [])],
+    visemeJawAmounts: [...(config.visemeJawAmounts || [])],
   };
 
   if (useResolvedNames) {
@@ -266,14 +275,81 @@ export function generateMappingCorrections(
     center: entry ? updateMorphList(entry.center, auId) : [],
   });
 
+  const updateVisemeBindings = (bindings?: VisemeBindings): VisemeBindings | undefined => {
+    if (!bindings) return undefined;
+    const next: VisemeBindings = {};
+    for (const [visemeId, binding] of Object.entries(bindings)) {
+      if (!binding) continue;
+      const updatedMorph = typeof binding.morph === 'string'
+        ? updateMorphList([binding.morph])[0]
+        : binding.morph;
+      next[visemeId as keyof VisemeBindings] = {
+        ...binding,
+        morph: updatedMorph,
+      };
+    }
+    return next;
+  };
+
+  const updateVisemeList = (items: VisemeMorphTargetRef[]): VisemeMorphTargetRef[] =>
+    items.slice(0, CANONICAL_VISEME_IDS.length).map((morphName) => {
+      if (typeof morphName !== 'string') {
+        return morphName;
+      }
+
+      if (modelMorphs.has(morphName)) return morphName;
+
+      const match = findBestMatch(morphName, modelMorphs, morphPrefix, morphSuffix, suffixPattern);
+      if (!match || match.confidence < minConfidence) {
+        unresolved.push({
+          type: 'morph',
+          source: morphName,
+          target: morphName,
+          confidence: match?.confidence ?? 0,
+          reason: match?.reason ?? 'no match',
+          applied: false,
+        });
+        return morphName;
+      }
+
+      const derivedBase = deriveBaseName(match.candidate, morphPrefix, morphSuffix);
+      const resolvedName = useResolvedNames || !derivedBase ? match.candidate : derivedBase;
+      const canApply = useResolvedNames || derivedBase !== null;
+
+      corrections.push({
+        type: 'morph',
+        source: morphName,
+        target: match.candidate,
+        confidence: match.confidence,
+        reason: match.reason,
+        applied: canApply && resolvedName !== morphName,
+      });
+
+      return canApply ? resolvedName : morphName;
+    }).concat(
+      Array.from({ length: Math.max(0, CANONICAL_VISEME_IDS.length - items.length) }, () => undefined)
+    );
+
   for (const [auIdStr, morphs] of Object.entries(config.auToMorphs)) {
     const auId = Number(auIdStr);
     correctedConfig.auToMorphs[auId] = updateMorphsBySide(morphs, auId);
   }
 
-  correctedConfig.visemeKeys = updateMorphList(config.visemeKeys).filter(
-    (key): key is string => typeof key === 'string'
-  );
+  correctedConfig.visemeBindings = updateVisemeBindings(config.visemeBindings);
+  correctedConfig.visemeKeys = correctedConfig.visemeBindings
+    ? compileVisemeKeys(
+        correctedConfig.visemeBindings,
+        config.visemeKeys || [],
+        config.visemeJawAmounts || []
+      )
+    : updateVisemeList(config.visemeKeys || []);
+  correctedConfig.visemeJawAmounts = correctedConfig.visemeBindings
+    ? compileVisemeJawAmounts(
+        correctedConfig.visemeBindings,
+        config.visemeKeys || [],
+        config.visemeJawAmounts || []
+      )
+    : [...(config.visemeJawAmounts || [])];
 
   // morphToMesh corrections
   for (const [category, meshList] of Object.entries(config.morphToMesh || {})) {

--- a/src/validation/validateMappings.ts
+++ b/src/validation/validateMappings.ts
@@ -8,6 +8,7 @@
 import type { RotationAxis } from '../core/types';
 import { toAUList } from '../core/compositeAxis';
 import type { Profile, MorphTargetsBySide, MorphTargetRef } from '../mappings/types';
+import { resolveVisemeBindings, type VisemeBinding, type CanonicalVisemeId } from '../mappings/visemes';
 import type { MappingCorrection, MappingCorrectionOptions } from './generateMappingCorrections';
 import { generateMappingCorrections } from './generateMappingCorrections';
 import type { ValidationMorphMesh as MorphMesh, ValidationSkeleton as Skeleton } from './types';
@@ -400,18 +401,55 @@ export function validateMappingConfig(config: Profile): MappingConsistencyResult
     }
   }
 
-  // Validate viseme keys (duplicates or blanks)
-  const visemeSeen = new Set<string>();
-  for (const key of config.visemeKeys || []) {
-    if (typeof key !== 'string') continue;
-    if (!key) {
-      push('warning', 'VISEME_EMPTY', 'Viseme key is empty');
-      continue;
+  if (config.visemeBindings) {
+    const morphToIds = new Map<string, CanonicalVisemeId[]>();
+    const bindingsById = config.visemeBindings;
+
+    for (const [id, binding] of Object.entries(bindingsById) as Array<[CanonicalVisemeId, VisemeBinding]>) {
+      if (!binding || binding.morph === undefined || binding.morph === null || binding.morph === '') {
+        push('warning', 'VISEME_EMPTY', `Viseme binding "${id}" is missing a morph target`, { id });
+        continue;
+      }
+
+      if (typeof binding.morph !== 'string') {
+        continue;
+      }
+
+      const ids = morphToIds.get(binding.morph) || [];
+      ids.push(id);
+      morphToIds.set(binding.morph, ids);
     }
-    if (visemeSeen.has(key)) {
-      push('warning', 'VISEME_DUPLICATE', `Viseme key "${key}" is duplicated`, { key });
+
+    for (const [morph, ids] of morphToIds.entries()) {
+      if (ids.length < 2) continue;
+
+      const sharedPairExists = ids.some((id) => {
+        const sharedWith = bindingsById[id]?.sharedWith || [];
+        return sharedWith.some((otherId) => ids.includes(otherId));
+      });
+
+      if (!sharedPairExists) {
+        push(
+          'warning',
+          'VISEME_SHARED_MORPH',
+          `Viseme morph "${morph}" is reused by ${ids.join(', ')} without sharedWith metadata`,
+          { morph, visemeIds: ids }
+        );
+      }
     }
-    visemeSeen.add(key);
+  } else {
+    const visemeSeen = new Set<string>();
+    for (const key of config.visemeKeys || []) {
+      if (typeof key !== 'string') continue;
+      if (!key) {
+        push('warning', 'VISEME_EMPTY', 'Viseme key is empty');
+        continue;
+      }
+      if (visemeSeen.has(key)) {
+        push('warning', 'VISEME_DUPLICATE', `Viseme key "${key}" is duplicated`, { key });
+      }
+      visemeSeen.add(key);
+    }
   }
 
   // Validate auMixDefaults
@@ -506,9 +544,13 @@ export function validateMappings(
       presetMorphs.add(morph);
     }
   }
-  for (const viseme of config.visemeKeys) {
-    if (typeof viseme === 'string') {
-      presetMorphs.add(viseme);
+  for (const viseme of resolveVisemeBindings(
+    config.visemeBindings,
+    config.visemeKeys || [],
+    config.visemeJawAmounts || []
+  )) {
+    if (typeof viseme.morph === 'string') {
+      presetMorphs.add(viseme.morph);
     }
   }
 


### PR DESCRIPTION
## Summary
- introduce a canonical viseme contract (`visemeBindings`) and helper utilities while keeping indexed runtime playback intact
- compile legacy `visemeKeys` / `visemeJawAmounts` from explicit bindings at the profile/runtime boundary
- clean up validation, correction, exports, tests, and docs so canonical viseme order and shared-morph reuse are explicit

## Testing
- `npm test -- src/mappings/visemes.test.ts src/mappings/resolveProfile.test.ts src/validation/__tests__/validateMappings.test.ts src/presets/__tests__/cc4.test.ts`
- `npm run typecheck`

Closes #56