### PR TITLE
[codex] Tighten eye annotation padding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,13 @@ Other `Profile` fields that are easy to miss:
 - `auMixDefaults` sets the default morph/bone blend weight per AU.
 - `compositeRotations` defines the per-node pitch/yaw/roll axis layout used by the composite rotation system.
 - `continuumPairs` and `continuumLabels` describe bidirectional AU pairs and their UI labels.
-- `annotationRegions` defines the regions used by the marker and camera tooling.
+- `annotationRegions` defines the regions used by the marker and camera tooling, including per-region framing via `paddingFactor`.
 - `hairPhysics` stores the mixer-driven hair defaults, including direction signs and morph target mappings.
+
+For `annotationRegions`, `paddingFactor` is the camera framing multiplier for that region:
+- values below `1` zoom in tighter
+- values above `1` pull back to show more surrounding context
+- profile overrides can replace it per region by name without copying the whole preset
 
 ### Passing a preset to Loom3
 
@@ -267,6 +272,8 @@ const DAISY_PROFILE: Profile = {
   morphToMesh: { face: ['Object_9'] },
   annotationRegions: [
     { name: 'face', bones: ['CC_Base_Head'] },
+    { name: 'left_eye', paddingFactor: 0.9 },
+    { name: 'right_eye', paddingFactor: 0.9 },
   ],
 };
 

--- a/src/characters/types.ts
+++ b/src/characters/types.ts
@@ -96,7 +96,10 @@ export interface Region {
   meshes?: string[];
   /** Any object names (bones or meshes). Use ['*'] for all objects */
   objects?: string[];
-  /** Override default padding factor for this annotation */
+  /**
+   * Camera framing multiplier for this annotation.
+   * Smaller values zoom in tighter; larger values leave more space around the target.
+   */
   paddingFactor?: number;
   /**
    * Camera angle in degrees around the Y axis (horizontal orbit).

--- a/src/mappings/types.ts
+++ b/src/mappings/types.ts
@@ -211,6 +211,10 @@ export interface AnnotationRegion {
   bones?: string[];
   meshes?: string[];
   objects?: string[];
+  /**
+   * Camera framing multiplier for this annotation.
+   * Smaller values zoom in tighter; larger values leave more space around the target.
+   */
   paddingFactor?: number;
   cameraAngle?: number;
   cameraOffset?: {

--- a/src/presets/__tests__/cc4.test.ts
+++ b/src/presets/__tests__/cc4.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   AU_TO_MORPHS,
   BONE_AU_TO_BINDINGS,
+  CC4_PRESET,
   COMPOSITE_ROTATIONS,
   CONTINUUM_PAIRS_MAP,
   VISEME_JAW_AMOUNTS,
@@ -390,6 +391,16 @@ describe('CC4 Preset', () => {
         expect(hasLeftRightBones(51)).toBe(false);
         expect(hasLeftRightBones(52)).toBe(false);
       });
+    });
+  });
+
+  describe('annotationRegions', () => {
+    it('uses tighter default camera framing for eye close-ups', () => {
+      const leftEye = CC4_PRESET.annotationRegions?.find((region) => region.name === 'left_eye');
+      const rightEye = CC4_PRESET.annotationRegions?.find((region) => region.name === 'right_eye');
+
+      expect(leftEye?.paddingFactor).toBe(0.9);
+      expect(rightEye?.paddingFactor).toBe(0.9);
     });
   });
 });

--- a/src/presets/cc4.ts
+++ b/src/presets/cc4.ts
@@ -1033,13 +1033,13 @@ export const CC4_PRESET: Profile = {
     {
       name: 'left_eye',
       bones: ['CC_Base_L_Eye'],
-      paddingFactor: 1.2,
+      paddingFactor: 0.9,
       parent: 'head',
     },
     {
       name: 'right_eye',
       bones: ['CC_Base_R_Eye'],
-      paddingFactor: 1.2,
+      paddingFactor: 0.9,
       parent: 'head',
     },
     {


### PR DESCRIPTION
## Summary
- tighten the CC4 `left_eye` and `right_eye` annotation region defaults from `1.2` to `0.9`
- document how `annotationRegions[].paddingFactor` affects camera framing in the README and type comments
- add a preset test that locks the eye-region default padding value

## Why
Issue #62 tracks that the persisted/profile-level eye annotation framing was too loose and the setting was under-documented. Lowering the default padding makes eye marker focus tighter by default, and the docs now make it clear that smaller values zoom in closer while larger values pull back.

## Impact
- future CC4-derived profiles inherit tighter eye close-ups by default
- developers can override the same setting per region by name in profile overrides
- README guidance now points directly at the profile-level knob used by persisted configs

## Validation
- `npm test -- src/presets/__tests__/cc4.test.ts`
- `npm run typecheck`

Closes #62.