### PR TITLE
move Jonathan annotation defaults into Loom3

### DIFF
--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -11,13 +11,22 @@ import {
 
 function createConfig(overrides: Partial<CharacterConfig> = {}): CharacterConfig {
   return {
-    characterId: 'jonathan',
-    characterName: 'Jonathan',
-    modelPath: '/jonathan.glb',
+    characterId: 'generic_humanoid',
+    characterName: 'Generic Humanoid',
+    modelPath: '/generic.glb',
     auPresetType: 'cc4',
     regions: [],
     ...overrides,
   };
+}
+
+function createJonathanConfig(overrides: Partial<CharacterConfig> = {}): CharacterConfig {
+  return createConfig({
+    characterId: 'jonathan',
+    characterName: 'Jonathan',
+    modelPath: '/jonathan.glb',
+    ...overrides,
+  });
 }
 
 describe('mergeRegionsByName', () => {
@@ -60,6 +69,55 @@ describe('mergeRegionsByName', () => {
 });
 
 describe('extendCharacterConfigWithPreset', () => {
+  it('fills preset regions for generic preset-backed characters when saved top-level regions are absent', () => {
+    const extended = extendCharacterConfigWithPreset(createConfig());
+    const face = extended.regions.find((region) => region.name === 'face');
+    const leftEye = extended.regions.find((region) => region.name === 'left_eye');
+
+    expect(extended.regions.map((region) => region.name).slice(0, 6)).toEqual([
+      'full_body',
+      'head',
+      'face',
+      'left_eye',
+      'right_eye',
+      'mouth',
+    ]);
+    expect(extended.regions.find((region) => region.name === 'head')?.children).toEqual([
+      'face',
+      'left_eye',
+      'right_eye',
+      'mouth',
+    ]);
+    expect(face?.paddingFactor).toBe(1.3);
+    expect(leftEye?.paddingFactor).toBe(0.9);
+    expect(leftEye?.cameraAngle).toBeUndefined();
+  });
+
+  it('applies Jonathan-specific Loom3 region defaults when saved top-level regions are absent', () => {
+    const extended = extendCharacterConfigWithPreset(createJonathanConfig());
+
+    const face = extended.regions.find((region) => region.name === 'face');
+    const leftEye = extended.regions.find((region) => region.name === 'left_eye');
+    const rightEye = extended.regions.find((region) => region.name === 'right_eye');
+
+    expect(face).toMatchObject({
+      name: 'face',
+      parent: 'head',
+      paddingFactor: 1.1,
+    });
+    expect(leftEye).toMatchObject({
+      name: 'left_eye',
+      parent: 'head',
+      paddingFactor: 0.5,
+    });
+    expect(leftEye?.cameraAngle).toBe(45);
+    expect(rightEye).toMatchObject({
+      name: 'right_eye',
+      parent: 'head',
+      paddingFactor: 0.5,
+    });
+    expect(rightEye?.cameraAngle).toBe(315);
+  });
   it('lets saved top-level regions override preset defaults by region name', () => {
     const presetRegions = getPresetWithProfile('cc4').annotationRegions ?? [];
     const extended = extendCharacterConfigWithPreset(
@@ -381,5 +439,25 @@ describe('applyCharacterProfileToPreset', () => {
       category: 'body',
       morphCount: 1,
     });
+  });
+
+  it('applies Jonathan-specific Loom3 overrides before saved per-character overrides', () => {
+    const resolvedProfile = applyCharacterProfileToPreset(
+      createJonathanConfig({
+        profile: {
+          annotationRegions: [{ name: 'left_eye', paddingFactor: 0.4 }],
+        },
+      })
+    );
+
+    const face = resolvedProfile?.annotationRegions?.find((region) => region.name === 'face');
+    const leftEye = resolvedProfile?.annotationRegions?.find((region) => region.name === 'left_eye');
+    const rightEye = resolvedProfile?.annotationRegions?.find((region) => region.name === 'right_eye');
+
+    expect(face?.paddingFactor).toBe(1.1);
+    expect(leftEye?.paddingFactor).toBe(0.4);
+    expect(leftEye?.cameraAngle).toBe(45);
+    expect(rightEye?.paddingFactor).toBe(0.5);
+    expect(rightEye?.cameraAngle).toBe(315);
   });
 });

--- a/src/characters/extendCharacterConfigWithPreset.ts
+++ b/src/characters/extendCharacterConfigWithPreset.ts
@@ -1,6 +1,7 @@
 import type { Profile } from '../mappings/types';
 import { extendPresetWithProfile } from '../mappings/extendPresetWithProfile';
 import { getPreset } from '../presets';
+import { resolveCharacterProfileOverrides } from '../presets/characterOverrides';
 import { normalizeRegionTree } from '../regions/normalizeRegionTree';
 import type { CharacterConfig, Region } from './types';
 
@@ -196,7 +197,12 @@ export function applyCharacterProfileToPreset(config: CharacterConfig): Profile 
     return null;
   }
 
-  return extendPresetWithProfile(getPreset(presetType), extractProfileOverrides(config));
+  const presetWithCharacterDefaults = extendPresetWithProfile(
+    getPreset(presetType),
+    resolveCharacterProfileOverrides(config.characterId)
+  );
+
+  return extendPresetWithProfile(presetWithCharacterDefaults, extractProfileOverrides(config));
 }
 
 function orderExtendedRegions(
@@ -234,9 +240,11 @@ function orderExtendedRegions(
  *
  * Precedence:
  * 1. preset defaults
- * 2. flattened top-level profile overrides
- * 3. legacy nested `config.profile` overrides (compatibility only)
- * 4. top-level saved `config.regions` overrides by region name
+ * 2. Loom3 character-specific preset overrides
+ * 3. flattened top-level profile overrides
+ * 4. legacy nested `config.profile` overrides (compatibility only)
+ * 5. top-level saved `config.regions` overrides by region name
+ * 6. top-level saved bone naming fields remain compatibility overrides
  */
 export function extendCharacterConfigWithPreset(config: CharacterConfig): CharacterConfig {
   const presetType = config.auPresetType;

--- a/src/presets/characterOverrides.ts
+++ b/src/presets/characterOverrides.ts
@@ -1,0 +1,23 @@
+import type { Profile } from '../mappings/types';
+
+const JONATHAN_PROFILE_OVERRIDES: Partial<Profile> = {
+  annotationRegions: [
+    { name: 'face', paddingFactor: 1.1 },
+    { name: 'left_eye', paddingFactor: 0.5, cameraAngle: 45 },
+    { name: 'right_eye', paddingFactor: 0.5, cameraAngle: 315 },
+  ],
+};
+
+const CHARACTER_PROFILE_OVERRIDES: Record<string, Partial<Profile>> = {
+  jonathan: JONATHAN_PROFILE_OVERRIDES,
+};
+
+export function resolveCharacterProfileOverrides(
+  characterId: string | undefined
+): Partial<Profile> | undefined {
+  if (!characterId) {
+    return undefined;
+  }
+
+  return CHARACTER_PROFILE_OVERRIDES[characterId.toLowerCase()];
+}


### PR DESCRIPTION
## Summary
- add a Loom3-owned Jonathan annotation override for face and eye framing
- apply character-specific defaults before saved profile and region overrides
- add resolver tests covering generic CC4 defaults, Jonathan defaults, and override precedence

## Validation
- npm test -- --run src/characters/resolveCharacterConfig.test.ts
- npm run typecheck
- npm run build

## Firestore
- cleared Jonathan's Firestore `config.regions` payload down to `[]` out-of-band so LoomLarge resolves its annotation defaults from Loom3 instead of stored per-region data