### PR TITLE
[codex] rename demo site links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Use the README in one of these paths:
 - Skeletal-only character: [Creating Skeletal Animation Presets](#6-creating-skeletal-animation-presets) -> [Baked Animations](#16-baked-animations) -> [Regions & Geometry Helpers](#17-regions--geometry-helpers)
 - Annotation or camera tooling: [Preset Selection & Validation](#3-preset-selection--validation) -> [Getting to Know Your Character](#4-getting-to-know-your-character) -> [Regions & Geometry Helpers](#17-regions--geometry-helpers)
 
-## Production Playground
+## Demo Site Links
 
-These links open the production LoomLarge drawer on the matching tab. Production currently supports stable `drawer` + `tab` deep links, so the README should lean on tab-specific links instead of pretending it can deep-link to a fully reconstructed authoring state.
+These demo site links open the LoomLarge drawer on the matching tab. The demo site currently supports stable `drawer` + `tab` deep links, so the README should lean on tab-specific links instead of pretending it can deep-link to a fully reconstructed authoring state.
 
 | Goal | Open in LoomLarge |
 |------|-------------------|


### PR DESCRIPTION
## What changed
- renamed the README section heading from `Production Playground` to `Demo Site Links`
- updated the intro sentence to refer to the LoomLarge demo site instead of production wording

## Why
- the earlier wording was misleading and not the preferred terminology for these README links
- this keeps the docs aligned with the intended phrasing: `demo site links`

## Impact
- docs-only wording change in `README.md`
- no runtime or API behavior changes

## Validation
- reviewed the diff locally
- no tests run because this is a docs-only edit