### PR TITLE
[codex] Refresh runtime state on profile hot-swap

### DIFF
--- a/src/engines/three/Loom3.setProfile.runtimeRefresh.test.ts
+++ b/src/engines/three/Loom3.setProfile.runtimeRefresh.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { Object3D } from 'three';
+import type { Profile } from '../../mappings/types';
+import { Loom3 } from './Loom3';
+
+function makeProfile(overrides: Partial<Profile>): Profile {
+  return {
+    auToMorphs: {},
+    auToBones: {},
+    boneNodes: {},
+    morphToMesh: { face: [] },
+    visemeKeys: [],
+    ...overrides,
+  };
+}
+
+function makeHeadJawRig() {
+  const model = new Object3D();
+  const head = new Object3D();
+  head.name = 'Head';
+  const jaw = new Object3D();
+  jaw.name = 'Jaw';
+  model.add(head, jaw);
+  return { model };
+}
+
+describe('Loom3 setProfile runtime refresh', () => {
+  it('registers newly added composite bone mappings after a profile hot-swap', () => {
+    const { model } = makeHeadJawRig();
+    const engine = new Loom3({
+      profile: makeProfile({
+        auToBones: {
+          1: [{ node: 'HEAD', channel: 'ry', scale: 1, maxDegrees: 30 }],
+        },
+        boneNodes: { HEAD: 'Head' },
+        compositeRotations: [
+          {
+            node: 'HEAD',
+            pitch: null,
+            yaw: { aus: [1], axis: 'ry' },
+            roll: null,
+          },
+        ],
+      }),
+    });
+
+    engine.onReady({ model, meshes: [] });
+
+    engine.setProfile(makeProfile({
+      auToBones: {
+        1: [{ node: 'HEAD', channel: 'ry', scale: 1, maxDegrees: 30 }],
+        80: [{ node: 'JAW', channel: 'rz', scale: 1, maxDegrees: 24 }],
+      },
+      boneNodes: {
+        HEAD: 'Head',
+        JAW: 'Jaw',
+      },
+      compositeRotations: [
+        {
+          node: 'HEAD',
+          pitch: null,
+          yaw: { aus: [1], axis: 'ry' },
+          roll: null,
+        },
+        {
+          node: 'JAW',
+          pitch: { aus: [80], axis: 'rz' },
+          yaw: null,
+          roll: null,
+        },
+      ],
+    }));
+
+    engine.setAU(80, 1);
+    engine.update(1 / 60);
+
+    const bones = engine.getBones();
+    expect(Math.abs(bones.JAW.rotation[2])).toBeGreaterThan(5);
+    expect(Math.abs(bones.HEAD.rotation[1])).toBeLessThan(0.001);
+  });
+
+  it('reapplies active AU state when the profile remaps a composite axis', () => {
+    const { model } = makeHeadJawRig();
+    const engine = new Loom3({
+      profile: makeProfile({
+        auToBones: {
+          1: [{ node: 'HEAD', channel: 'ry', scale: 1, maxDegrees: 30 }],
+        },
+        boneNodes: { HEAD: 'Head' },
+        compositeRotations: [
+          {
+            node: 'HEAD',
+            pitch: null,
+            yaw: { aus: [1], axis: 'ry' },
+            roll: null,
+          },
+        ],
+      }),
+    });
+
+    engine.onReady({ model, meshes: [] });
+    engine.setAU(1, 1);
+    engine.update(1 / 60);
+
+    const before = engine.getBones().HEAD.rotation;
+    expect(Math.abs(before[1])).toBeGreaterThan(20);
+    expect(Math.abs(before[0])).toBeLessThan(0.001);
+
+    engine.setProfile(makeProfile({
+      auToBones: {
+        1: [{ node: 'HEAD', channel: 'rx', scale: 1, maxDegrees: 12 }],
+      },
+      boneNodes: { HEAD: 'Head' },
+      compositeRotations: [
+        {
+          node: 'HEAD',
+          pitch: { aus: [1], axis: 'rx' },
+          yaw: null,
+          roll: null,
+        },
+      ],
+    }));
+    engine.update(1 / 60);
+
+    const after = engine.getBones().HEAD.rotation;
+    expect(Math.abs(after[0])).toBeGreaterThan(8);
+    expect(Math.abs(after[1])).toBeLessThan(0.001);
+  });
+});

--- a/src/engines/three/Loom3.setProfile.runtimeRefresh.test.ts
+++ b/src/engines/three/Loom3.setProfile.runtimeRefresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Object3D } from 'three';
+import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D } from 'three';
 import type { Profile } from '../../mappings/types';
 import { Loom3 } from './Loom3';
 
@@ -22,6 +22,15 @@ function makeHeadJawRig() {
   jaw.name = 'Jaw';
   model.add(head, jaw);
   return { model };
+}
+
+function makeMorphMesh(name: string, dictionary: Record<string, number>): Mesh {
+  const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
+  mesh.name = name;
+  (mesh as any).morphTargetDictionary = dictionary;
+  const maxIndex = Object.values(dictionary).length > 0 ? Math.max(...Object.values(dictionary)) : -1;
+  (mesh as any).morphTargetInfluences = maxIndex >= 0 ? new Array(maxIndex + 1).fill(0) : [];
+  return mesh;
 }
 
 describe('Loom3 setProfile runtime refresh', () => {
@@ -125,5 +134,97 @@ describe('Loom3 setProfile runtime refresh', () => {
     const after = engine.getBones().HEAD.rotation;
     expect(Math.abs(after[0])).toBeGreaterThan(8);
     expect(Math.abs(after[1])).toBeLessThan(0.001);
+  });
+
+  it('clears stale AU morph targets when an active AU remaps to different meshes', () => {
+    const model = new Object3D();
+    const faceMesh = makeMorphMesh('FaceMesh', { Smile: 0 });
+    const altMesh = makeMorphMesh('AltMesh', { Smile: 0 });
+    model.add(faceMesh, altMesh);
+
+    const engine = new Loom3({
+      profile: makeProfile({
+        auToMorphs: {
+          1: { left: [], right: [], center: ['Smile'] },
+        },
+        morphToMesh: { face: ['FaceMesh'], alt: ['AltMesh'] },
+      }),
+    });
+
+    engine.onReady({ model, meshes: [faceMesh, altMesh] });
+    engine.setAU(1, 1);
+
+    expect(faceMesh.morphTargetInfluences?.[0]).toBe(1);
+    expect(altMesh.morphTargetInfluences?.[0]).toBe(0);
+
+    engine.setProfile(makeProfile({
+      auToMorphs: {
+        1: { left: [], right: [], center: ['Smile'] },
+      },
+      morphToMesh: { face: ['AltMesh'], alt: ['FaceMesh'] },
+    }));
+
+    expect(faceMesh.morphTargetInfluences?.[0]).toBe(0);
+    expect(altMesh.morphTargetInfluences?.[0]).toBe(1);
+  });
+
+  it('reapplies active viseme morphs and jaw rotation after a profile hot-swap', () => {
+    const { model } = makeHeadJawRig();
+    const faceMesh = makeMorphMesh('FaceMesh', { Viseme_AA: 0 });
+    const visemeMesh = makeMorphMesh('VisemeMesh', { Viseme_AA: 0 });
+    model.add(faceMesh, visemeMesh);
+
+    const engine = new Loom3({
+      profile: makeProfile({
+        auToBones: {
+          26: [{ node: 'JAW', channel: 'rz', scale: 1, maxDegrees: 30 }],
+        },
+        boneNodes: { JAW: 'Jaw' },
+        morphToMesh: { face: ['FaceMesh'], viseme: ['VisemeMesh'] },
+        visemeKeys: ['Viseme_AA'],
+        visemeMeshCategory: 'face',
+        visemeJawAmounts: [0.2],
+        compositeRotations: [
+          {
+            node: 'JAW',
+            pitch: { aus: [26], axis: 'rz' },
+            yaw: null,
+            roll: null,
+          },
+        ],
+      }),
+    });
+
+    engine.onReady({ model, meshes: [faceMesh, visemeMesh] });
+    engine.setViseme(0, 1, 0.5);
+    engine.update(1 / 60);
+
+    expect(faceMesh.morphTargetInfluences?.[0]).toBe(1);
+    expect(visemeMesh.morphTargetInfluences?.[0]).toBe(0);
+    expect(Math.abs(engine.getBones().JAW.rotation[2])).toBeGreaterThan(2.5);
+
+    engine.setProfile(makeProfile({
+      auToBones: {
+        26: [{ node: 'JAW', channel: 'rz', scale: 1, maxDegrees: 30 }],
+      },
+      boneNodes: { JAW: 'Jaw' },
+      morphToMesh: { face: ['FaceMesh'], viseme: ['VisemeMesh'] },
+      visemeKeys: ['Viseme_AA'],
+      visemeMeshCategory: 'viseme',
+      visemeJawAmounts: [0.6],
+      compositeRotations: [
+        {
+          node: 'JAW',
+          pitch: { aus: [26], axis: 'rz' },
+          yaw: null,
+          roll: null,
+        },
+      ],
+    }));
+    engine.update(1 / 60);
+
+    expect(faceMesh.morphTargetInfluences?.[0]).toBe(0);
+    expect(visemeMesh.morphTargetInfluences?.[0]).toBe(1);
+    expect(Math.abs(engine.getBones().JAW.rotation[2])).toBeGreaterThan(8.5);
   });
 });

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -1003,6 +1003,31 @@ export class Loom3 implements LoomLarge {
     });
   }
 
+  private rebuildActiveRuntimeState(): void {
+    this.clearTransitions();
+    this.translations = {};
+    this.initBoneRotations();
+
+    Object.values(this.bones).forEach((entry) => {
+      if (!entry) return;
+      entry.obj.position.copy(entry.basePos as any);
+      entry.obj.quaternion.copy(entry.baseQuat);
+      entry.obj.updateMatrixWorld(false);
+    });
+
+    for (const [auIdStr, value] of Object.entries(this.auValues)) {
+      if (value <= 0) continue;
+      const auId = Number(auIdStr);
+      if (Number.isNaN(auId)) continue;
+      this.setAU(auId, value, this.auBalances[auId]);
+    }
+
+    if (this.model) {
+      this.flushPendingComposites();
+      this.model.updateMatrixWorld(true);
+    }
+  }
+
   // ============================================================================
   // MESH CONTROL
   // ============================================================================
@@ -1296,12 +1321,17 @@ export class Loom3 implements LoomLarge {
 
   setProfile(profile: Profile): void {
     this.config = profile;
+    this.compositeRotations = this.config.compositeRotations || CC4_COMPOSITE_ROTATIONS;
+    this.auToCompositeMap = buildAUToCompositeMap(this.compositeRotations);
     this.mixWeights = { ...profile.auMixDefaults };
     if (this.model) {
+      this.bones = this.resolveBones(this.model);
+      this.missingBoneWarnings.clear();
       this.rebuildMorphTargetsCache();
     }
     this.hairPhysics.refreshMeshSelection();
     this.applyHairPhysicsProfileConfig();
+    this.rebuildActiveRuntimeState();
   }
 
   getProfile(): Profile { return this.config; }
@@ -1657,6 +1687,7 @@ export class Loom3 implements LoomLarge {
 
   private resolveBones(root: Object3D): ResolvedBones {
     const resolved: ResolvedBones = {};
+    const previousBones = this.bones;
 
     const snapshot = (obj: any): NodeBase => ({
       obj,
@@ -1664,6 +1695,20 @@ export class Loom3 implements LoomLarge {
       baseQuat: obj.quaternion.clone(),
       baseEuler: { x: obj.rotation.x, y: obj.rotation.y, z: obj.rotation.z, order: obj.rotation.order },
     });
+
+    const snapshotForObject = (obj: Object3D): NodeBase => {
+      const existing = Object.values(previousBones).find((entry) => entry?.obj === obj);
+      if (!existing) {
+        return snapshot(obj);
+      }
+
+      return {
+        obj,
+        basePos: { ...existing.basePos },
+        baseQuat: existing.baseQuat.clone(),
+        baseEuler: { ...existing.baseEuler },
+      };
+    };
 
     // Build suffix regex from config pattern
     const prefix = this.config.bonePrefix || '';
@@ -1714,20 +1759,20 @@ export class Loom3 implements LoomLarge {
     for (const [key, nodeName] of Object.entries(this.config.boneNodes)) {
       const node = findNode(nodeName);
       if (node) {
-        resolved[key] = snapshot(node);
+        resolved[key] = snapshotForObject(node);
       }
     }
 
     if (!resolved.EYE_L && this.config.eyeMeshNodes) {
       const node = findNode(this.config.eyeMeshNodes.LEFT);
       if (node) {
-        resolved.EYE_L = snapshot(node);
+        resolved.EYE_L = snapshotForObject(node);
       }
     }
     if (!resolved.EYE_R && this.config.eyeMeshNodes) {
       const node = findNode(this.config.eyeMeshNodes.RIGHT);
       if (node) {
-        resolved.EYE_R = snapshot(node);
+        resolved.EYE_R = snapshotForObject(node);
       }
     }
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -1003,7 +1003,7 @@ export class Loom3 implements LoomLarge {
     });
   }
 
-  private rebuildActiveRuntimeState(): void {
+  private reinitializeRuntimeStateFromCurrentAUs(): void {
     this.clearTransitions();
     this.translations = {};
     this.initBoneRotations();
@@ -1331,7 +1331,7 @@ export class Loom3 implements LoomLarge {
     }
     this.hairPhysics.refreshMeshSelection();
     this.applyHairPhysicsProfileConfig();
-    this.rebuildActiveRuntimeState();
+    this.reinitializeRuntimeStateFromCurrentAUs();
   }
 
   getProfile(): Profile { return this.config; }
@@ -1696,7 +1696,7 @@ export class Loom3 implements LoomLarge {
       baseEuler: { x: obj.rotation.x, y: obj.rotation.y, z: obj.rotation.z, order: obj.rotation.order },
     });
 
-    const snapshotForObject = (obj: Object3D): NodeBase => {
+    const snapshotPreservingBasePose = (obj: Object3D): NodeBase => {
       const existing = Object.values(previousBones).find((entry) => entry?.obj === obj);
       if (!existing) {
         return snapshot(obj);
@@ -1759,20 +1759,20 @@ export class Loom3 implements LoomLarge {
     for (const [key, nodeName] of Object.entries(this.config.boneNodes)) {
       const node = findNode(nodeName);
       if (node) {
-        resolved[key] = snapshotForObject(node);
+        resolved[key] = snapshotPreservingBasePose(node);
       }
     }
 
     if (!resolved.EYE_L && this.config.eyeMeshNodes) {
       const node = findNode(this.config.eyeMeshNodes.LEFT);
       if (node) {
-        resolved.EYE_L = snapshotForObject(node);
+        resolved.EYE_L = snapshotPreservingBasePose(node);
       }
     }
     if (!resolved.EYE_R && this.config.eyeMeshNodes) {
       const node = findNode(this.config.eyeMeshNodes.RIGHT);
       if (node) {
-        resolved.EYE_R = snapshotForObject(node);
+        resolved.EYE_R = snapshotPreservingBasePose(node);
       }
     }
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -140,7 +140,8 @@ export class Loom3 implements LoomLarge {
   private mixWeights: Record<number, number> = {};
 
   // Viseme state
-  private visemeValues: number[] = new Array(15).fill(0);
+  private visemeValues: number[] = [];
+  private visemeJawScales: number[] = [];
 
 
   // Viseme jaw amounts
@@ -176,6 +177,7 @@ export class Loom3 implements LoomLarge {
     const basePreset = config.presetType ? getPreset(config.presetType) : CC4_PRESET;
     this.config = extendPresetWithProfile(basePreset, config.profile);
     this.mixWeights = { ...this.config.auMixDefaults };
+    this.syncVisemeRuntimeState();
     this.animation = animation || new AnimationThree();
 
     // Use config's composite rotations or default to CC4
@@ -898,6 +900,7 @@ export class Loom3 implements LoomLarge {
 
     const val = clamp01(value);
     this.visemeValues[visemeIndex] = val;
+    this.visemeJawScales[visemeIndex] = jawScale;
 
     const targets = this.resolvedVisemeTargets[visemeIndex];
     if (targets && targets.length > 0) {
@@ -912,7 +915,7 @@ export class Loom3 implements LoomLarge {
       }
     }
 
-    const jawAmount = Loom3.VISEME_JAW_AMOUNTS[visemeIndex] * val * jawScale;
+    const jawAmount = this.getVisemeJawAmount(visemeIndex) * val * jawScale;
     if (Math.abs(jawScale) > 1e-6 && Math.abs(jawAmount) > 1e-6) {
       this.updateBoneRotation('JAW', 'pitch', jawAmount);
     }
@@ -926,13 +929,14 @@ export class Loom3 implements LoomLarge {
     const morphKey = this.config.visemeKeys[visemeIndex];
     const target = clamp01(to);
     this.visemeValues[visemeIndex] = target;
+    this.visemeJawScales[visemeIndex] = jawScale;
     const visemeMeshNames = this.getMeshNamesForViseme();
 
     const morphHandle = typeof morphKey === 'number'
       ? this.transitionMorphInfluence(morphKey, target, durationMs, visemeMeshNames)
       : this.transitionMorph(morphKey, target, durationMs, visemeMeshNames);
 
-    const jawAmount = Loom3.VISEME_JAW_AMOUNTS[visemeIndex] * target * jawScale;
+    const jawAmount = this.getVisemeJawAmount(visemeIndex) * target * jawScale;
     if (Math.abs(jawScale) <= 1e-6 || Math.abs(jawAmount) <= 1e-6) {
       return morphHandle;
     }
@@ -985,6 +989,9 @@ export class Loom3 implements LoomLarge {
 
   resetToNeutral(): void {
     this.auValues = {};
+    this.visemeValues = new Array(this.config.visemeKeys.length).fill(0);
+    this.visemeJawScales = new Array(this.config.visemeKeys.length).fill(1);
+    this.translations = {};
     this.initBoneRotations();
     this.clearTransitions();
 
@@ -1003,8 +1010,9 @@ export class Loom3 implements LoomLarge {
     });
   }
 
-  private reinitializeRuntimeStateFromCurrentAUs(): void {
+  private reinitializeRuntimeStateFromCurrentControls(staleMorphTargets: MorphTargetHandle[] = []): void {
     this.clearTransitions();
+    this.resetMorphTargetHandles(staleMorphTargets);
     this.translations = {};
     this.initBoneRotations();
 
@@ -1020,6 +1028,12 @@ export class Loom3 implements LoomLarge {
       const auId = Number(auIdStr);
       if (Number.isNaN(auId)) continue;
       this.setAU(auId, value, this.auBalances[auId]);
+    }
+
+    for (let visemeIndex = 0; visemeIndex < this.visemeValues.length; visemeIndex += 1) {
+      const value = this.visemeValues[visemeIndex] ?? 0;
+      if (value <= 0) continue;
+      this.setViseme(visemeIndex, value, this.visemeJawScales[visemeIndex] ?? 1);
     }
 
     if (this.model) {
@@ -1324,14 +1338,17 @@ export class Loom3 implements LoomLarge {
     this.compositeRotations = this.config.compositeRotations || CC4_COMPOSITE_ROTATIONS;
     this.auToCompositeMap = buildAUToCompositeMap(this.compositeRotations);
     this.mixWeights = { ...profile.auMixDefaults };
+    this.syncVisemeRuntimeState();
+    let staleMorphTargets: MorphTargetHandle[] = [];
     if (this.model) {
+      staleMorphTargets = this.collectResolvedExpressionMorphTargets();
       this.bones = this.resolveBones(this.model);
       this.missingBoneWarnings.clear();
       this.rebuildMorphTargetsCache();
     }
     this.hairPhysics.refreshMeshSelection();
     this.applyHairPhysicsProfileConfig();
-    this.reinitializeRuntimeStateFromCurrentAUs();
+    this.reinitializeRuntimeStateFromCurrentControls(staleMorphTargets);
   }
 
   getProfile(): Profile { return this.config; }
@@ -1499,6 +1516,48 @@ export class Loom3 implements LoomLarge {
 
   private getMorphIndexCacheKey(index: number, meshNames?: string[]): string {
     return meshNames?.length ? `idx:${index}@${meshNames.join(',')}` : `idx:${index}`;
+  }
+
+  private syncVisemeRuntimeState(): void {
+    const visemeCount = this.config.visemeKeys.length;
+    this.visemeValues = Array.from(
+      { length: visemeCount },
+      (_, index) => this.visemeValues[index] ?? 0
+    );
+    this.visemeJawScales = Array.from(
+      { length: visemeCount },
+      (_, index) => this.visemeJawScales[index] ?? 1
+    );
+  }
+
+  private getVisemeJawAmount(visemeIndex: number): number {
+    return this.config.visemeJawAmounts?.[visemeIndex]
+      ?? Loom3.VISEME_JAW_AMOUNTS[visemeIndex]
+      ?? 0;
+  }
+
+  private collectResolvedExpressionMorphTargets(): MorphTargetHandle[] {
+    const targets: MorphTargetHandle[] = [];
+
+    for (const resolved of this.resolvedAUMorphTargets.values()) {
+      targets.push(...resolved.left, ...resolved.right, ...resolved.center);
+    }
+
+    for (const resolved of this.resolvedVisemeTargets) {
+      if (resolved?.length) {
+        targets.push(...resolved);
+      }
+    }
+
+    return targets;
+  }
+
+  private resetMorphTargetHandles(targets: MorphTargetHandle[]): void {
+    for (const { infl, idx } of targets) {
+      if (idx < infl.length) {
+        infl[idx] = 0;
+      }
+    }
   }
 
   private isMixedAU(id: number): boolean {


### PR DESCRIPTION
## What changed
- refresh `compositeRotations` and the derived AU-to-composite map inside `setProfile()`
- re-resolve bones against the loaded model when the profile changes
- preserve original base transforms for already-resolved bones instead of snapshotting the current posed transform
- rebuild active runtime bone state after a profile hot-swap by resetting composite/translation state and replaying active AU values
- add regression coverage for hot-swapping in new composite bone mappings and remapping an already-active AU to a different axis

## Why
Bone-axis authoring in LoomLarge needs runtime profile edits to take effect immediately. Before this change, `setProfile()` updated the stored profile object but did not rebuild the composite rotation runtime, did not resolve newly added semantic bones from the loaded model, and could accidentally treat the current posed transform as the new base pose when bones were re-resolved.

That meant newly authored bone mappings could fail to move at all, and remapped active AUs could keep stale orientation baked into the runtime.

## Impact
- new bone-axis mappings added during authoring can be exercised immediately in Loom3 without reloading the character
- remapped active AUs now reapply against the updated composite axis definition
- newly introduced semantic bone nodes can resolve against the current model during authoring flows

## Validation
- `npx vitest run src/engines/three/Loom3.setProfile.runtimeRefresh.test.ts src/engines/three/Loom3.compositeAxisGroups.test.ts src/engines/three/Loom3.eyeBones.test.ts src/engines/three/Loom3.eyeBalance.test.ts`
- `npm run typecheck`