### PR TITLE
fix: canonicalize annotation preset extension

### DIFF
--- a/ANNOTATION_CONFIGURATION.md
+++ b/ANNOTATION_CONFIGURATION.md
@@ -1,18 +1,15 @@
 # Annotation Configuration
 
-Loom3 exposes annotation configuration through `annotationRegions` on `Profile`, but the current LoomLarge demo/runtime still reads top-level `CharacterConfig.regions` as the live source of truth.
+Loom3 exposes annotation configuration through `annotationRegions` on `Profile`, and `extendCharacterConfigWithPreset(...)` projects that canonical preset/profile shape into the runtime `config.regions` surface consumed by camera and marker tooling.
 
-> Note
-> Annotations have not been moved from the demo project into Loom3 yet, but we plan to move them soon.
+There are still two related shapes to know about:
 
-This means there are two related shapes to know about:
+1. The canonical Loom3 preset/profile shape: `annotationRegions`
+2. The runtime/legacy mirror on `CharacterConfig`: `config.regions`
 
-1. The Loom3 profile shape: `profile.annotationRegions`
-2. The current LoomLarge runtime shape: `config.regions`
+## Runtime Resolution
 
-## Current Runtime Truth
-
-Today, the camera and marker runtime in LoomLarge reads top-level region entries like this:
+Camera and marker tooling in LoomLarge still consumes top-level region entries like this:
 
 ```ts
 const config = {
@@ -39,7 +36,14 @@ const config = {
 };
 ```
 
-If you are trying to change what the current LoomLarge camera does, this is the shape that is active today.
+When you call `extendCharacterConfigWithPreset(...)`, Loom3 resolves these shapes with this precedence:
+
+1. preset `annotationRegions`
+2. profile `annotationRegions` overrides by region name
+3. legacy nested `config.profile.annotationRegions` for compatibility
+4. top-level `config.regions` only as a fallback when canonical annotation overrides are absent
+
+If canonical annotation overrides exist, legacy `config.regions` entries are only preserved for non-preset extras that do not collide by region name.
 
 ## Loom3 Profile Shape
 
@@ -189,10 +193,10 @@ For common behavior shared by a preset:
 1. Put the default region behavior in the Loom3 preset under `annotationRegions`.
 2. Override only the fields that truly differ for a specific character.
 
-For the current LoomLarge runtime:
+For runtime compatibility:
 
-1. Put the active camera/marker settings in top-level `config.regions`.
-2. Treat `profile.annotationRegions` as the intended Loom3-native shape, not the currently consumed demo-app source of truth.
+1. Prefer `annotationRegions` for stored profile overrides and preset extensions.
+2. Treat top-level `config.regions` as the runtime mirror or a legacy fallback input, not the canonical authoring surface.
 
 ## Example: Eye Closeup
 

--- a/ANNOTATION_CONFIGURATION.md
+++ b/ANNOTATION_CONFIGURATION.md
@@ -1,18 +1,15 @@
 # Annotation Configuration
 
-Loom3 exposes annotation configuration through `annotationRegions` on `Profile`, but the current LoomLarge demo/runtime still reads top-level `CharacterConfig.regions` as the live source of truth.
+Loom3 exposes annotation configuration through `annotationRegions` on `Profile`, and `extendCharacterConfigWithPreset(...)` projects that canonical preset/profile shape into the runtime `config.regions` surface consumed by camera and marker tooling.
 
-> Note
-> Annotations have not been moved from the demo project into Loom3 yet, but we plan to move them soon.
+There are still two related shapes to know about:
 
-This means there are two related shapes to know about:
+1. The canonical Loom3 preset/profile shape: `annotationRegions`
+2. The runtime/legacy mirror on `CharacterConfig`: `config.regions`
 
-1. The Loom3 profile shape: `profile.annotationRegions`
-2. The current LoomLarge runtime shape: `config.regions`
+## Runtime Extension
 
-## Current Runtime Truth
-
-Today, the camera and marker runtime in LoomLarge reads top-level region entries like this:
+Camera and marker tooling in LoomLarge still consumes top-level region entries like this:
 
 ```ts
 const config = {
@@ -39,7 +36,14 @@ const config = {
 };
 ```
 
-If you are trying to change what the current LoomLarge camera does, this is the shape that is active today.
+When you call `extendCharacterConfigWithPreset(...)`, Loom3 extends these shapes with this precedence:
+
+1. preset `annotationRegions`
+2. profile `annotationRegions` overrides by region name
+3. legacy nested `config.profile.annotationRegions` for compatibility
+4. top-level `config.regions` only as a fallback when canonical annotation overrides are absent
+
+If canonical annotation overrides exist, legacy `config.regions` entries are only preserved for non-preset extras that do not collide by region name.
 
 ## Loom3 Profile Shape
 
@@ -189,10 +193,10 @@ For common behavior shared by a preset:
 1. Put the default region behavior in the Loom3 preset under `annotationRegions`.
 2. Override only the fields that truly differ for a specific character.
 
-For the current LoomLarge runtime:
+For runtime compatibility:
 
-1. Put the active camera/marker settings in top-level `config.regions`.
-2. Treat `profile.annotationRegions` as the intended Loom3-native shape, not the currently consumed demo-app source of truth.
+1. Prefer `annotationRegions` for stored profile overrides and preset extensions.
+2. Treat top-level `config.regions` as the runtime mirror or a legacy fallback input, not the canonical authoring surface.
 
 ## Example: Eye Closeup
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ For the current runtime-oriented documentation, including:
 - `cameraOffset`
 - `style.lineDirection`
 - the difference between `cameraAngle: 0` and omitting `cameraAngle`
-- the current LoomLarge runtime note that annotations have not been moved from the demo project into Loom3 yet
+- runtime compatibility and legacy `config.regions` fallback behavior
 
 see [ANNOTATION_CONFIGURATION.md](./ANNOTATION_CONFIGURATION.md).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Loom3 provides mappings that connect [Facial Action Coding System (FACS)](https:
 
 Loom3 is broader than a face-controller wrapper. The library spans four practical areas:
 - Runtime control: Action Units, visemes, direct morphs, continuum pairs, composite rotations, transitions, and mixer playback.
-- Rig configuration: built-in presets, profile overrides, preset resolution, name resolution, viseme routing, mix weights, and skeletal-only preset support.
+- Rig configuration: built-in presets, profile overrides, preset lookup and extension, name resolution, viseme routing, mix weights, and skeletal-only preset support.
 - Inspection and validation: mesh, morph, and bone discovery; preset-fit checks; correction suggestions; and full model analysis.
 - Runtime tooling: mesh/material debugging, baked animation clip helpers, hair physics, and region/geometry helpers for annotation or camera tooling.
 
@@ -380,7 +380,7 @@ Open in LoomLarge: [Properties tab](https://loomlarge.web.app/?drawer=open&tab=p
 
 Before you tune AUs or hand-edit a profile, confirm that you picked the right preset and that the model actually matches it. Loom3 exposes a full preset-selection and validation workflow, not just low-level control APIs.
 
-### Resolving presets by type
+### Looking Up and Extending Presets by Type
 
 Use preset helpers when you want a stable entry point by model class instead of importing a preset constant directly:
 

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -6,6 +6,8 @@
 - CC4 now includes independent eye AUs 65-72 for both morph and bone mappings.
 - Composite eye axes now evaluate per-node effective values consistently, so shared-eye balance no longer leaks into independent-eye controls.
 - CC4 head yaw/pitch/roll max degrees were increased for wider head turns.
+- Preset-backed character configs now extend canonical `annotationRegions` into the runtime `regions` mirror, preserving legacy `regions` only as fallback input or non-preset extras.
+- Annotation region profile overrides now merge by region name and preserve nested camera/style fields such as partial `cameraOffset` updates.
 
 ### Playback and mixer updates
 - Clip stop now resolves cleanly, so stopping playback does not throw a rejected promise.
@@ -17,4 +19,5 @@
 ### Morph routing and docs
 - Morph targeting prefers `morphToMesh.face` when present and falls back to scanning meshes for morph keys.
 - README terminology now uses `Loom3` as the primary name, with `@lovelace_lol/loom3` as the package import.
-- The docs now reflect the current viseme keys, preset merge helper, and profile fields that the code actually exports.
+- The docs now reflect the current viseme keys, preset extension helpers, and profile fields that the code actually exports.
+- Publish versions are computed by `.github/workflows/publish.yml` from the current npm version or release tag before `npm publish`; the committed `package.json` version is only the baseline used by that workflow.

--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -57,14 +57,38 @@ describe('mergeRegionsByName', () => {
       },
     ]);
   });
+
+  it('merges nested camera offsets by axis instead of replacing the whole vector', () => {
+    const merged = mergeRegionsByName(
+      [
+        {
+          name: 'head',
+          cameraOffset: { x: 1, y: 2, z: 3 },
+        },
+      ],
+      [
+        {
+          name: 'head',
+          cameraOffset: { y: 9 },
+        },
+      ]
+    );
+
+    expect(merged).toEqual([
+      {
+        name: 'head',
+        cameraOffset: { x: 1, y: 9, z: 3 },
+      },
+    ]);
+  });
 });
 
 describe('extendCharacterConfigWithPreset', () => {
-  it('lets saved top-level regions override preset defaults by region name', () => {
+  it('lets saved annotationRegions override preset defaults by region name', () => {
     const presetRegions = getPresetWithProfile('cc4').annotationRegions ?? [];
     const extended = extendCharacterConfigWithPreset(
       createConfig({
-        regions: presetRegions.map((region) =>
+        annotationRegions: presetRegions.map((region) =>
           region.name === 'left_eye'
             ? { ...region, cameraAngle: 45, paddingFactor: 0.5 }
             : region.name === 'right_eye'
@@ -98,9 +122,13 @@ describe('extendCharacterConfigWithPreset', () => {
       paddingFactor: 0.5,
     });
     expect(rightEye?.cameraAngle).toBe(315);
+    expect(extended.annotationRegions?.find((region) => region.name === 'left_eye')).toMatchObject({
+      cameraAngle: 45,
+      paddingFactor: 0.5,
+    });
   });
 
-  it('merges saved top-level regions over preset regions while preserving preset geometry', () => {
+  it('treats saved top-level regions as a legacy fallback when annotationRegions are absent', () => {
     const presetRightEye = getPresetWithProfile('cc4').annotationRegions?.find(
       (region) => region.name === 'right_eye'
     );
@@ -164,7 +192,7 @@ describe('extendCharacterConfigWithPreset', () => {
     ]);
   });
 
-  it('prefers canonical annotation regions over legacy region fallbacks during migration', () => {
+  it('prefers canonical annotationRegions over legacy regions while preserving legacy extras', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({
         profile: {
@@ -201,6 +229,32 @@ describe('extendCharacterConfigWithPreset', () => {
     });
   });
 
+  it('keeps preset order when canonical annotationRegions only override a subset', () => {
+    const extended = extendCharacterConfigWithPreset(
+      createConfig({
+        annotationRegions: [
+          { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
+        ],
+      })
+    );
+
+    expect(extended.regions.slice(0, 6).map((region) => region.name)).toEqual([
+      'full_body',
+      'head',
+      'face',
+      'left_eye',
+      'right_eye',
+      'mouth',
+    ]);
+    expect(extended.regions.find((region) => region.name === 'left_eye')).toMatchObject({
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      cameraAngle: 45,
+      paddingFactor: 0.5,
+      parent: 'head',
+    });
+  });
+
   it('drops disabled preset regions after extension and cleans parent-child links', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({
@@ -217,14 +271,14 @@ describe('extendCharacterConfigWithPreset', () => {
     ]);
   });
 
-  it('carries preset bone resolution metadata needed by runtime consumers', () => {
+  it('carries preset bone metadata needed by runtime consumers', () => {
     const extended = extendCharacterConfigWithPreset(createConfig());
 
     expect(extended.suffixPattern).toBeDefined();
     expect(extended.boneNodes).toBeDefined();
   });
 
-  it('lets semantic annotation region bones resolve through preset bone nodes plus profile affixes', () => {
+  it('lets semantic annotation region bones use preset bone nodes plus profile affixes', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({
         characterId: 'trex',
@@ -371,6 +425,24 @@ describe('extractProfileOverrides', () => {
     });
     expect(overrides.disabledRegions).toEqual(['mouth']);
     expect(overrides.annotationRegions).toBeUndefined();
+  });
+
+  it('prefers canonical annotationRegions over legacy runtime regions during extraction', () => {
+    const overrides = extractProfileOverrides(
+      createConfig({
+        annotationRegions: [
+          { name: 'left_eye', cameraAngle: 30, paddingFactor: 1.1 },
+        ],
+        regions: [
+          { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
+          { name: 'hat', objects: ['HatMesh'], paddingFactor: 1.4 },
+        ],
+      })
+    );
+
+    expect(overrides.annotationRegions).toEqual([
+      { name: 'left_eye', cameraAngle: 30, paddingFactor: 1.1 },
+    ]);
   });
 });
 

--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -255,32 +255,6 @@ describe('extendCharacterConfigWithPreset', () => {
     });
   });
 
-  it('keeps preset order when canonical annotationRegions only override a subset', () => {
-    const extended = extendCharacterConfigWithPreset(
-      createConfig({
-        annotationRegions: [
-          { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
-        ],
-      })
-    );
-
-    expect(extended.regions.slice(0, 6).map((region) => region.name)).toEqual([
-      'full_body',
-      'head',
-      'face',
-      'left_eye',
-      'right_eye',
-      'mouth',
-    ]);
-    expect(extended.regions.find((region) => region.name === 'left_eye')).toMatchObject({
-      name: 'left_eye',
-      bones: ['EYE_L'],
-      cameraAngle: 45,
-      paddingFactor: 0.5,
-      parent: 'head',
-    });
-  });
-
   it('drops disabled preset regions after extension and cleans parent-child links', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({

--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -57,14 +57,38 @@ describe('mergeRegionsByName', () => {
       },
     ]);
   });
+
+  it('merges nested camera offsets by axis instead of replacing the whole vector', () => {
+    const merged = mergeRegionsByName(
+      [
+        {
+          name: 'head',
+          cameraOffset: { x: 1, y: 2, z: 3 },
+        },
+      ],
+      [
+        {
+          name: 'head',
+          cameraOffset: { y: 9 },
+        },
+      ]
+    );
+
+    expect(merged).toEqual([
+      {
+        name: 'head',
+        cameraOffset: { x: 1, y: 9, z: 3 },
+      },
+    ]);
+  });
 });
 
 describe('extendCharacterConfigWithPreset', () => {
-  it('lets saved top-level regions override preset defaults by region name', () => {
+  it('lets saved annotationRegions override preset defaults by region name', () => {
     const presetRegions = getPresetWithProfile('cc4').annotationRegions ?? [];
     const extended = extendCharacterConfigWithPreset(
       createConfig({
-        regions: presetRegions.map((region) =>
+        annotationRegions: presetRegions.map((region) =>
           region.name === 'left_eye'
             ? { ...region, cameraAngle: 45, paddingFactor: 0.5 }
             : region.name === 'right_eye'
@@ -98,9 +122,13 @@ describe('extendCharacterConfigWithPreset', () => {
       paddingFactor: 0.5,
     });
     expect(rightEye?.cameraAngle).toBe(315);
+    expect(extended.annotationRegions?.find((region) => region.name === 'left_eye')).toMatchObject({
+      cameraAngle: 45,
+      paddingFactor: 0.5,
+    });
   });
 
-  it('merges saved top-level regions over preset regions while preserving preset geometry', () => {
+  it('treats saved top-level regions as a legacy fallback when annotationRegions are absent', () => {
     const presetRightEye = getPresetWithProfile('cc4').annotationRegions?.find(
       (region) => region.name === 'right_eye'
     );
@@ -164,7 +192,7 @@ describe('extendCharacterConfigWithPreset', () => {
     ]);
   });
 
-  it('still honors legacy nested profile annotation overrides during migration', () => {
+  it('prefers canonical annotationRegions over legacy regions while preserving legacy extras', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({
         profile: {
@@ -175,22 +203,29 @@ describe('extendCharacterConfigWithPreset', () => {
         },
         regions: [
           { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
+          { name: 'hat', objects: ['HatMesh'], paddingFactor: 1.4 },
         ],
       })
     );
 
     const leftEye = extended.regions.find((region) => region.name === 'left_eye');
     const mouth = extended.regions.find((region) => region.name === 'mouth');
+    const hat = extended.regions.find((region) => region.name === 'hat');
 
     expect(leftEye).toMatchObject({
       name: 'left_eye',
       bones: ['EYE_L'],
-      paddingFactor: 0.5,
-      cameraAngle: 45,
+      paddingFactor: 1.1,
+      cameraAngle: 30,
       parent: 'head',
     });
     expect(mouth?.style).toMatchObject({
       lineDirection: 'camera',
+    });
+    expect(hat).toMatchObject({
+      name: 'hat',
+      objects: ['HatMesh'],
+      paddingFactor: 1.4,
     });
   });
 
@@ -364,6 +399,24 @@ describe('extractProfileOverrides', () => {
     });
     expect(overrides.disabledRegions).toEqual(['mouth']);
     expect(overrides.annotationRegions).toBeUndefined();
+  });
+
+  it('prefers canonical annotationRegions over legacy runtime regions during extraction', () => {
+    const overrides = extractProfileOverrides(
+      createConfig({
+        annotationRegions: [
+          { name: 'left_eye', cameraAngle: 30, paddingFactor: 1.1 },
+        ],
+        regions: [
+          { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
+          { name: 'hat', objects: ['HatMesh'], paddingFactor: 1.4 },
+        ],
+      })
+    );
+
+    expect(overrides.annotationRegions).toEqual([
+      { name: 'left_eye', cameraAngle: 30, paddingFactor: 1.1 },
+    ]);
   });
 });
 

--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -128,6 +128,32 @@ describe('extendCharacterConfigWithPreset', () => {
     });
   });
 
+  it('keeps preset order when canonical annotationRegions only override a subset', () => {
+    const extended = extendCharacterConfigWithPreset(
+      createConfig({
+        annotationRegions: [
+          { name: 'left_eye', cameraAngle: 45, paddingFactor: 0.5 },
+        ],
+      })
+    );
+
+    expect(extended.regions.slice(0, 6).map((region) => region.name)).toEqual([
+      'full_body',
+      'head',
+      'face',
+      'left_eye',
+      'right_eye',
+      'mouth',
+    ]);
+    expect(extended.regions.find((region) => region.name === 'left_eye')).toMatchObject({
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      cameraAngle: 45,
+      paddingFactor: 0.5,
+      parent: 'head',
+    });
+  });
+
   it('treats saved top-level regions as a legacy fallback when annotationRegions are absent', () => {
     const presetRightEye = getPresetWithProfile('cc4').annotationRegions?.find(
       (region) => region.name === 'right_eye'

--- a/src/characters/extendCharacterConfigWithPreset.ts
+++ b/src/characters/extendCharacterConfigWithPreset.ts
@@ -152,32 +152,38 @@ export function mergeRegionsByName(base?: Region[], override?: Region[]): Region
   return Array.from(merged.values());
 }
 
+function getAnnotationRegions(value: unknown): Region[] | undefined {
+  return Array.isArray(value) ? value as Region[] : undefined;
+}
+
+function getLegacyNestedOverrides(config: CharacterConfig): Record<string, unknown> {
+  return isPlainObject(config.profile) ? config.profile as Record<string, unknown> : {};
+}
+
+function getLegacyRuntimeRegions(config: CharacterConfig): Region[] | undefined {
+  return Array.isArray(config.regions) && config.regions.length > 0 ? config.regions : undefined;
+}
+
+function getCanonicalAnnotationOverrides(config: CharacterConfig): Region[] | undefined {
+  return mergeRegionsByName(
+    getAnnotationRegions(getLegacyNestedOverrides(config).annotationRegions),
+    getAnnotationRegions((config as unknown as Record<string, unknown>).annotationRegions),
+  );
+}
+
 export function extractProfileOverrides(config: CharacterConfig): Partial<Profile> {
   const topLevelConfig = config as unknown as Record<string, unknown>;
-  const legacyNestedOverrides = isPlainObject(config.profile)
-    ? config.profile as Record<string, unknown>
-    : {};
+  const legacyNestedOverrides = getLegacyNestedOverrides(config);
+  const canonicalAnnotationOverrides = getCanonicalAnnotationOverrides(config);
+  const legacyRuntimeRegions = getLegacyRuntimeRegions(config);
+  const annotationOverrides = canonicalAnnotationOverrides
+    ?? (legacyRuntimeRegions ? legacyRuntimeRegions.map((region) => cloneRegion(region)) : undefined);
   const overrides: Partial<Profile> = {};
 
   for (const key of PROFILE_OVERRIDE_KEYS) {
     if (key === 'annotationRegions') {
-      const topLevelAnnotationRegions = Array.isArray(topLevelConfig.annotationRegions)
-        ? topLevelConfig.annotationRegions as Region[]
-        : undefined;
-      const legacyAnnotationRegions = Array.isArray(legacyNestedOverrides.annotationRegions)
-        ? legacyNestedOverrides.annotationRegions as Region[]
-        : undefined;
-      const legacyRegionFallback = Array.isArray(config.regions) && config.regions.length > 0
-        ? config.regions
-        : undefined;
-      const legacyProfileRegions = mergeRegionsByName(legacyRegionFallback, legacyAnnotationRegions);
-      const regions = mergeRegionsByName(
-        legacyProfileRegions,
-        topLevelAnnotationRegions
-      );
-
-      if (regions) {
-        overrides.annotationRegions = regions.map((region) => cloneRegion(region));
+      if (annotationOverrides) {
+        overrides.annotationRegions = annotationOverrides.map((region) => cloneRegion(region));
       }
       continue;
     }
@@ -191,18 +197,6 @@ export function extractProfileOverrides(config: CharacterConfig): Partial<Profil
   }
 
   return overrides;
-}
-
-function hasCanonicalAnnotationRegionOverrides(config: CharacterConfig): boolean {
-  const topLevelConfig = config as unknown as Record<string, unknown>;
-  if (Array.isArray(topLevelConfig.annotationRegions)) {
-    return true;
-  }
-
-  return (
-    isPlainObject(config.profile) &&
-    Array.isArray((config.profile as Record<string, unknown>).annotationRegions)
-  );
 }
 
 export function applyCharacterProfileToPreset(config: CharacterConfig): Profile | null {
@@ -249,10 +243,9 @@ function orderExtendedRegions(
  *
  * Precedence:
  * 1. preset defaults
- * 2. saved `config.regions` overrides, or fallbacks when `annotationRegions`
- *    is present
+ * 2. canonical flattened `annotationRegions` / top-level profile overrides
  * 3. legacy nested `config.profile` overrides (compatibility only)
- * 4. flattened top-level profile overrides
+ * 4. legacy `config.regions` fallback only when canonical annotation overrides are absent
  */
 export function extendCharacterConfigWithPreset(config: CharacterConfig): CharacterConfig {
   const presetType = config.auPresetType;
@@ -260,27 +253,41 @@ export function extendCharacterConfigWithPreset(config: CharacterConfig): Charac
     return config;
   }
 
+  const canonicalAnnotationOverrides = getCanonicalAnnotationOverrides(config);
+  const legacyRuntimeRegions = getLegacyRuntimeRegions(config);
   const profileOverrides = extractProfileOverrides(config);
   const extendedPresetProfile = applyCharacterProfileToPreset(config);
   if (!extendedPresetProfile) {
     return config;
   }
-  const presetRegions = extendedPresetProfile.annotationRegions as Region[] | undefined;
-  const mergedRegions = hasCanonicalAnnotationRegionOverrides(config)
-    ? mergeRegionsByName(config.regions, presetRegions)
-    : mergeRegionsByName(presetRegions, config.regions);
-  const normalizedRegions = normalizeRegionTree(
-    mergedRegions,
+  const presetRegionNames = new Set(
+    ((getPreset(presetType).annotationRegions as Region[] | undefined) ?? []).map((region) => region.name)
+  );
+  const extendedAnnotationRegions = normalizeRegionTree(
+    extendedPresetProfile.annotationRegions as Region[] | undefined,
+    profileOverrides.disabledRegions,
+  );
+  const extendedRegionNames = new Set((extendedAnnotationRegions ?? []).map((region) => region.name));
+  const legacyExtraRegions = canonicalAnnotationOverrides && legacyRuntimeRegions
+    ? legacyRuntimeRegions
+        .filter((region) => !presetRegionNames.has(region.name) && !extendedRegionNames.has(region.name))
+        .map((region) => cloneRegion(region))
+    : undefined;
+  const mergedRegions = normalizeRegionTree(
+    mergeRegionsByName(extendedAnnotationRegions, legacyExtraRegions),
     profileOverrides.disabledRegions,
   );
   const extendedRegions = orderExtendedRegions(
-    normalizedRegions,
-    [config.regions, profileOverrides.annotationRegions as Region[] | undefined, presetRegions]
+    mergedRegions,
+    canonicalAnnotationOverrides
+      ? [extendedAnnotationRegions, legacyExtraRegions]
+      : [legacyRuntimeRegions, extendedAnnotationRegions]
   );
 
   return {
     ...config,
     ...extendedPresetProfile,
+    annotationRegions: extendedRegions ?? extendedAnnotationRegions,
     regions: extendedRegions ?? config.regions,
   };
 }

--- a/src/characters/extendCharacterConfigWithPreset.ts
+++ b/src/characters/extendCharacterConfigWithPreset.ts
@@ -152,29 +152,38 @@ export function mergeRegionsByName(base?: Region[], override?: Region[]): Region
   return Array.from(merged.values());
 }
 
+function getAnnotationRegions(value: unknown): Region[] | undefined {
+  return Array.isArray(value) ? value as Region[] : undefined;
+}
+
+function getLegacyNestedOverrides(config: CharacterConfig): Record<string, unknown> {
+  return isPlainObject(config.profile) ? config.profile as Record<string, unknown> : {};
+}
+
+function getLegacyRuntimeRegions(config: CharacterConfig): Region[] | undefined {
+  return Array.isArray(config.regions) && config.regions.length > 0 ? config.regions : undefined;
+}
+
+function getCanonicalAnnotationOverrides(config: CharacterConfig): Region[] | undefined {
+  return mergeRegionsByName(
+    getAnnotationRegions(getLegacyNestedOverrides(config).annotationRegions),
+    getAnnotationRegions((config as unknown as Record<string, unknown>).annotationRegions),
+  );
+}
+
 export function extractProfileOverrides(config: CharacterConfig): Partial<Profile> {
   const topLevelConfig = config as unknown as Record<string, unknown>;
-  const legacyNestedOverrides = isPlainObject(config.profile)
-    ? config.profile as Record<string, unknown>
-    : {};
+  const legacyNestedOverrides = getLegacyNestedOverrides(config);
+  const canonicalAnnotationOverrides = getCanonicalAnnotationOverrides(config);
+  const legacyRuntimeRegions = getLegacyRuntimeRegions(config);
+  const annotationOverrides = canonicalAnnotationOverrides
+    ?? (legacyRuntimeRegions ? legacyRuntimeRegions.map((region) => cloneRegion(region)) : undefined);
   const overrides: Partial<Profile> = {};
 
   for (const key of PROFILE_OVERRIDE_KEYS) {
     if (key === 'annotationRegions') {
-      const topLevelAnnotationRegions = Array.isArray(topLevelConfig.annotationRegions)
-        ? topLevelConfig.annotationRegions as Region[]
-        : undefined;
-      const legacyAnnotationRegions = Array.isArray(legacyNestedOverrides.annotationRegions)
-        ? legacyNestedOverrides.annotationRegions as Region[]
-        : undefined;
-      const presetOverrideRegions = mergeRegionsByName(legacyAnnotationRegions, topLevelAnnotationRegions);
-      const regions = mergeRegionsByName(
-        presetOverrideRegions,
-        Array.isArray(config.regions) && config.regions.length > 0 ? config.regions : undefined
-      );
-
-      if (regions) {
-        overrides.annotationRegions = regions.map((region) => cloneRegion(region));
+      if (annotationOverrides) {
+        overrides.annotationRegions = annotationOverrides.map((region) => cloneRegion(region));
       }
       continue;
     }
@@ -234,9 +243,9 @@ function orderExtendedRegions(
  *
  * Precedence:
  * 1. preset defaults
- * 2. flattened top-level profile overrides
+ * 2. canonical flattened `annotationRegions` / top-level profile overrides
  * 3. legacy nested `config.profile` overrides (compatibility only)
- * 4. top-level saved `config.regions` overrides by region name
+ * 4. legacy `config.regions` fallback only when canonical annotation overrides are absent
  */
 export function extendCharacterConfigWithPreset(config: CharacterConfig): CharacterConfig {
   const presetType = config.auPresetType;
@@ -244,25 +253,41 @@ export function extendCharacterConfigWithPreset(config: CharacterConfig): Charac
     return config;
   }
 
+  const canonicalAnnotationOverrides = getCanonicalAnnotationOverrides(config);
+  const legacyRuntimeRegions = getLegacyRuntimeRegions(config);
   const profileOverrides = extractProfileOverrides(config);
   const extendedPresetProfile = applyCharacterProfileToPreset(config);
   if (!extendedPresetProfile) {
     return config;
   }
-  const presetRegions = extendedPresetProfile.annotationRegions as Region[] | undefined;
-  const mergedRegions = mergeRegionsByName(presetRegions, config.regions);
-  const normalizedRegions = normalizeRegionTree(
-    mergedRegions,
+  const presetRegionNames = new Set(
+    ((getPreset(presetType).annotationRegions as Region[] | undefined) ?? []).map((region) => region.name)
+  );
+  const resolvedAnnotationRegions = normalizeRegionTree(
+    extendedPresetProfile.annotationRegions as Region[] | undefined,
+    profileOverrides.disabledRegions,
+  );
+  const resolvedRegionNames = new Set((resolvedAnnotationRegions ?? []).map((region) => region.name));
+  const legacyExtraRegions = canonicalAnnotationOverrides && legacyRuntimeRegions
+    ? legacyRuntimeRegions
+        .filter((region) => !presetRegionNames.has(region.name) && !resolvedRegionNames.has(region.name))
+        .map((region) => cloneRegion(region))
+    : undefined;
+  const mergedRegions = normalizeRegionTree(
+    mergeRegionsByName(resolvedAnnotationRegions, legacyExtraRegions),
     profileOverrides.disabledRegions,
   );
   const extendedRegions = orderExtendedRegions(
-    normalizedRegions,
-    [config.regions, profileOverrides.annotationRegions as Region[] | undefined, presetRegions]
+    mergedRegions,
+    canonicalAnnotationOverrides
+      ? [canonicalAnnotationOverrides, resolvedAnnotationRegions, legacyExtraRegions]
+      : [legacyRuntimeRegions, resolvedAnnotationRegions]
   );
 
   return {
     ...config,
     ...extendedPresetProfile,
+    annotationRegions: extendedRegions ?? resolvedAnnotationRegions,
     regions: extendedRegions ?? config.regions,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export {
 // Fish/skeletal preset
 export { BETTA_FISH_PRESET, AU_MAPPING_CONFIG, FISH_AU_MAPPING_CONFIG } from './presets/bettaFish';
 
-// Preset resolution by type name
+// Preset lookup and profile extension by type name
 export {
   getPreset,
   getPresetWithProfile,

--- a/src/mappings/extendPresetWithProfile.test.ts
+++ b/src/mappings/extendPresetWithProfile.test.ts
@@ -51,6 +51,32 @@ describe('extendPresetWithProfile', () => {
     expect(mouth?.bones).toEqual(['Jaw']);
   });
 
+  it('merges annotation camera offsets by axis instead of replacing the whole vector', () => {
+    const result = extendPresetWithProfile(
+      {
+        ...basePreset,
+        annotationRegions: [
+          {
+            name: 'face',
+            bones: ['Head'],
+            cameraOffset: { x: 1, y: 2, z: 3 },
+          },
+        ],
+      },
+      {
+        annotationRegions: [
+          { name: 'face', cameraOffset: { y: 9 } },
+        ],
+      }
+    );
+
+    expect(result.annotationRegions?.find((region) => region.name === 'face')?.cameraOffset).toEqual({
+      x: 1,
+      y: 9,
+      z: 3,
+    });
+  });
+
   it('carries disabled region names without pruning annotation regions', () => {
     const result = extendPresetWithProfile(
       {

--- a/src/mappings/extendPresetWithProfile.ts
+++ b/src/mappings/extendPresetWithProfile.ts
@@ -52,7 +52,7 @@ const mergeAnnotationRegion = (
   merged.objects = override.objects ? [...override.objects] : base.objects ? [...base.objects] : undefined;
   merged.children = override.children ? [...override.children] : base.children ? [...base.children] : undefined;
   merged.cameraOffset = override.cameraOffset
-    ? { ...override.cameraOffset }
+    ? { ...base.cameraOffset, ...override.cameraOffset }
     : base.cameraOffset
       ? { ...base.cameraOffset }
       : undefined;
@@ -139,7 +139,7 @@ const mergeHairPhysicsConfig = (
  * - Scalars: extension wins when provided.
  * - Maps: shallow-merged by key, values cloned.
  * - Arrays: replaced when the extension provides them (except annotationRegions).
- * - annotationRegions: merged by region name, shallow field merge (extension wins).
+ * - annotationRegions: merged by region name, with nested camera/style fields preserved.
  */
 export function extendPresetWithProfile(base: Profile, extension?: Partial<Profile>): Profile {
   if (!extension) {

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -2,7 +2,7 @@
  * Loom3 - Preset Exports
  *
  * All AU presets are exported from here.
- * Frontend passes a presetType string and Loom3 looks up the preset internally.
+ * Frontend passes a presetType string and Loom3 looks up or extends the preset internally.
  */
 
 // CC4 preset (default for humanoid characters)
@@ -49,7 +49,7 @@ export function getPreset(presetType: PresetType | string | undefined) {
   }
 }
 
-// Backwards-compatible alias retained for LoomLarge consumers.
+// Backwards-compatible lookup alias retained for LoomLarge consumers.
 export const resolvePreset = getPreset;
 
 /**
@@ -62,5 +62,5 @@ export function getPresetWithProfile(
   return extendPresetWithProfile(getPreset(presetType), profile);
 }
 
-// Backwards-compatible alias retained for LoomLarge consumers.
+// Backwards-compatible extension alias retained for LoomLarge consumers.
 export const resolvePresetWithOverrides = getPresetWithProfile;


### PR DESCRIPTION
## Summary
- treat `annotationRegions` as the canonical preset/profile annotation surface in the shared character-config extender
- keep legacy top-level `regions` as a fallback/runtime mirror instead of letting them overwrite canonical annotation overrides
- preserve nested annotation camera offsets during preset/profile extension and update the annotation docs to describe the actual precedence rules

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`

## Context
- Companion library-side follow-up to LoomLarge PR #334 so the shared Loom3 helpers match the app-side canonical annotation flow.
- Dependent frontend PR: [meekmachine/LoomLarge#513](https://github.com/meekmachine/LoomLarge/pull/513).