### PR TITLE
[codex] Guard unsafe baked additive playback

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -100,6 +100,9 @@ export type AnimationSource = 'baked' | 'clip' | 'snippet';
 /** Shared blend-mode surface for downstream animation UIs. */
 export type AnimationBlendMode = 'replace' | 'additive';
 
+/** Reason an additive request was coerced to a safer effective blend mode. */
+export type AnimationBlendModeFallbackReason = 'unsafe_baked_additive_tracks';
+
 /** Shared easing labels for downstream animation UIs. */
 export type AnimationEasing = 'linear' | 'easeInOut' | 'easeInOutCubic' | 'easeIn' | 'easeOut';
 
@@ -151,6 +154,10 @@ export interface AnimationClipInfo {
   trackCount: number;
   /** Source of the clip for downstream UI grouping */
   source?: AnimationSource;
+  /** Whether baked additive playback is considered safe for this clip */
+  supportsAdditive?: boolean;
+  /** Reason additive playback is unsafe for this clip, when known */
+  additiveModeReason?: AnimationBlendModeFallbackReason;
 }
 
 /**
@@ -181,8 +188,14 @@ export interface AnimationState {
   weight: number;
   /** Shared balance metadata for downstream UIs */
   balance: number;
+  /** Requested blend mode before any runtime safety coercion. */
+  requestedBlendMode: AnimationBlendMode;
   /** Shared blend metadata for downstream UIs */
   blendMode: AnimationBlendMode;
+  /** Whether additive playback is considered safe for this clip */
+  supportsAdditive?: boolean;
+  /** Reason additive playback is unsafe for this clip, when known */
+  additiveModeReason?: AnimationBlendModeFallbackReason;
   /** Shared easing metadata for downstream UIs */
   easing: AnimationEasing;
   /** Whether the animation is looping */

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -5,21 +5,44 @@ import {
   MeshBasicMaterial,
   NumberKeyframeTrack,
   Object3D,
+  QuaternionKeyframeTrack,
   BufferGeometry,
 } from 'three';
 import type { Profile } from '../../mappings/types';
 import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
 
-function makeHost(): { controller: BakedAnimationController; model: Object3D } {
+function makeHost(options: { includeHeadBone?: boolean } = {}): {
+  controller: BakedAnimationController;
+  model: Object3D;
+  head: Object3D | null;
+} {
   const model = new Object3D();
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
   mesh.name = 'FaceMesh';
+  (mesh as any).morphTargetInfluences = [0];
+  (mesh as any).morphTargetDictionary = { smile: 0 };
   model.add(mesh);
+  const head = options.includeHeadBone ? new Object3D() : null;
+  if (head) {
+    head.name = 'Head';
+    model.add(head);
+  }
+
+  const bones = head
+    ? {
+        HEAD: {
+          obj: head,
+          basePos: { x: head.position.x, y: head.position.y, z: head.position.z },
+          baseQuat: head.quaternion.clone(),
+          baseEuler: { x: head.rotation.x, y: head.rotation.y, z: head.rotation.z, order: head.rotation.order },
+        },
+      }
+    : {};
 
   const profile: Profile = {
     auToMorphs: {},
     auToBones: {},
-    boneNodes: {},
+    boneNodes: head ? { HEAD: 'Head' } : {},
     morphToMesh: { face: ['FaceMesh'] },
     visemeKeys: [],
   };
@@ -28,7 +51,7 @@ function makeHost(): { controller: BakedAnimationController; model: Object3D } {
     getModel: () => model,
     getMeshes: () => [mesh],
     getMeshByName: (name: string) => (name === 'FaceMesh' ? mesh : undefined),
-    getBones: () => ({} as any),
+    getBones: () => bones as any,
     getConfig: () => profile,
     getCompositeRotations: () => [],
     computeSideValues: (base: number) => ({ left: base, right: base }),
@@ -36,19 +59,31 @@ function makeHost(): { controller: BakedAnimationController; model: Object3D } {
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), model };
+  return { controller: new BakedAnimationController(host), model, head };
 }
 
-function makeClip(model: Object3D, name: string): AnimationClip {
+function makeTransformClip(model: Object3D, name: string): AnimationClip {
   return new AnimationClip(name, 1, [
     new NumberKeyframeTrack(`${model.uuid}.position[x]`, [0, 1], [0, 1]),
   ]);
 }
 
+function makeMorphClip(name: string): AnimationClip {
+  return new AnimationClip(name, 1, [
+    new NumberKeyframeTrack('FaceMesh.morphTargetInfluences[0]', [0, 1], [0, 1]),
+  ]);
+}
+
+function makeSafeBoneClip(head: Object3D, name: string): AnimationClip {
+  return new AnimationClip(name, 1, [
+    new QuaternionKeyframeTrack(`${head.uuid}.quaternion`, [0, 1], [0, 0, 0, 1, 0, 0, 0, 1]),
+  ]);
+}
+
 describe('BakedAnimationController playback state normalization', () => {
   it('normalizes baked clip options into the shared animation state surface', () => {
-    const { controller, model } = makeHost();
-    controller.loadAnimationClips([makeClip(model, 'Idle')]);
+    const { controller } = makeHost();
+    controller.loadAnimationClips([makeMorphClip('Idle')]);
 
     const handle = controller.playAnimation('Idle', {
       playbackRate: 1.5,
@@ -75,18 +110,43 @@ describe('BakedAnimationController playback state normalization', () => {
       loop: true,
       loopMode: 'pingpong',
       repeatCount: 3,
+      requestedBlendMode: 'additive',
       blendMode: 'additive',
+      supportsAdditive: true,
       balance: 0.25,
       easing: 'easeInOut',
     });
     expect(state?.actionId).toBeTruthy();
     expect(state?.time).toBeCloseTo(0.7, 5);
     expect(controller.getAnimationClips()[0]?.source).toBe('baked');
+    expect(controller.getAnimationClips()[0]?.supportsAdditive).toBe(true);
+  });
+
+  it('allows additive baked playback for resolved facial/head transform tracks', () => {
+    const { controller, head } = makeHost({ includeHeadBone: true });
+    expect(head).toBeTruthy();
+    controller.loadAnimationClips([makeSafeBoneClip(head!, 'HeadNod')]);
+
+    const handle = controller.playAnimation('HeadNod', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    expect(controller.getAnimationState('HeadNod')).toMatchObject({
+      name: 'HeadNod',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+    expect(controller.getAnimationClips()[0]).toMatchObject({
+      name: 'HeadNod',
+      supportsAdditive: true,
+    });
   });
 
   it('applies the same normalized aliases to clip-backed playback', () => {
     const { controller, model } = makeHost();
-    const clip = makeClip(model, 'Wave');
+    const clip = makeTransformClip(model, 'Wave');
 
     const handle = controller.playClip(clip, {
       source: 'snippet',
@@ -113,7 +173,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
   it('respects baked startTime and replays after stop without losing the action', () => {
     const { controller, model } = makeHost();
-    controller.loadAnimationClips([makeClip(model, 'Idle')]);
+    controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
 
     const firstHandle = controller.playAnimation('Idle', { startTime: 0.7 });
     expect(firstHandle).toBeTruthy();
@@ -134,8 +194,8 @@ describe('BakedAnimationController playback state normalization', () => {
   it('removes baked clips from subsequent list and playback queries', () => {
     const { controller, model } = makeHost();
     controller.loadAnimationClips([
-      makeClip(model, 'Idle'),
-      makeClip(model, 'Wave'),
+      makeTransformClip(model, 'Idle'),
+      makeTransformClip(model, 'Wave'),
     ]);
 
     const handle = controller.playAnimation('Idle');
@@ -150,8 +210,8 @@ describe('BakedAnimationController playback state normalization', () => {
 
   it('starts reverse once playback from the clip end for baked and clip-backed actions', () => {
     const { controller, model } = makeHost();
-    const clip = makeClip(model, 'Wave');
-    controller.loadAnimationClips([makeClip(model, 'Idle')]);
+    const clip = makeTransformClip(model, 'Wave');
+    controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
 
     controller.playAnimation('Idle', {
       loopMode: 'once',
@@ -177,5 +237,44 @@ describe('BakedAnimationController playback state normalization', () => {
 
     handle?.play();
     expect(controller.getAnimationState('Wave')?.time).toBeCloseTo(1, 5);
+  });
+
+  it('falls back to replace when additive is requested for baked transform clips', () => {
+    const { controller, model } = makeHost();
+    controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
+
+    const handle = controller.playAnimation('Idle', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    expect(controller.getAnimationState('Idle')).toMatchObject({
+      name: 'Idle',
+      requestedBlendMode: 'additive',
+      blendMode: 'replace',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
+    });
+    expect(controller.getAnimationClips()[0]).toMatchObject({
+      name: 'Idle',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
+    });
+  });
+
+  it('keeps unsafe baked clips on replace when additive is toggled after playback starts', () => {
+    const { controller, model } = makeHost();
+    controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
+
+    controller.playAnimation('Idle');
+    controller.setAnimationBlendMode('Idle', 'additive');
+
+    expect(controller.getAnimationState('Idle')).toMatchObject({
+      name: 'Idle',
+      requestedBlendMode: 'additive',
+      blendMode: 'replace',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
+    });
   });
 });

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -15,6 +15,7 @@ import {
   LoopPingPong,
   LoopOnce,
   NormalAnimationBlendMode,
+  PropertyBinding,
   Quaternion,
   Vector3,
 } from 'three';
@@ -34,6 +35,7 @@ import type {
   RotationAxis,
   AnimationSource,
   AnimationBlendMode,
+  AnimationBlendModeFallbackReason,
   AnimationEasing,
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
@@ -206,8 +208,14 @@ type NormalizedPlaybackState = {
   playbackRate: number;
   weight: number;
   balance: number;
+  requestedBlendMode: AnimationBlendMode;
   blendMode: AnimationBlendMode;
   easing: AnimationEasing;
+};
+
+type AdditiveSupport = {
+  supported: boolean;
+  reason?: AnimationBlendModeFallbackReason;
 };
 
 export class BakedAnimationController {
@@ -221,6 +229,7 @@ export class BakedAnimationController {
   private clipHandles = new Map<string, ClipHandle>();
   private clipSources = new Map<string, AnimationSource>();
   private playbackState = new Map<string, NormalizedPlaybackState>();
+  private additiveSupport = new Map<string, AdditiveSupport>();
   private actionIds = new WeakMap<AnimationAction, string>();
   private actionIdToClip = new Map<string, string>();
 
@@ -254,6 +263,7 @@ export class BakedAnimationController {
       ?? (typeof options?.loop === 'boolean'
         ? (options.loop ? 'repeat' : 'once')
         : (defaults.loop ? 'repeat' : 'once'));
+    const requestedBlendMode = options?.blendMode ?? (clipOptions?.mixerAdditive ? 'additive' : 'replace');
     return {
       source: options?.source ?? defaults.source,
       loop: loopMode !== 'once',
@@ -263,7 +273,8 @@ export class BakedAnimationController {
       playbackRate,
       weight,
       balance: Number.isFinite(options?.balance) ? options?.balance ?? 0 : 0,
-      blendMode: options?.blendMode ?? (clipOptions?.mixerAdditive ? 'additive' : 'replace'),
+      requestedBlendMode,
+      blendMode: requestedBlendMode,
       easing: options?.easing ?? 'linear',
     };
   }
@@ -344,16 +355,126 @@ export class BakedAnimationController {
     }
 
     if (options.blendMode) {
-      next.blendMode = options.blendMode;
+      next.requestedBlendMode = options.blendMode;
     } else if (typeof clipOptions?.mixerAdditive === 'boolean') {
-      next.blendMode = clipOptions.mixerAdditive ? 'additive' : 'replace';
+      next.requestedBlendMode = clipOptions.mixerAdditive ? 'additive' : 'replace';
     }
+    next.blendMode = next.requestedBlendMode;
 
     if (options.easing) {
       next.easing = options.easing;
     }
 
     return next;
+  }
+
+  private analyzeAdditiveSupport(clip: AnimationClip): AdditiveSupport {
+    const model = this.host.getModel();
+    if (!model) {
+      return {
+        supported: false,
+        reason: 'unsafe_baked_additive_tracks',
+      };
+    }
+
+    const safeTransformTargets = new Set(
+      Object.values(this.host.getBones())
+        .map((entry) => entry?.obj)
+        .filter(Boolean)
+    );
+
+    const unsupportedTracks = clip.tracks.filter((track) => {
+      const trackName = typeof track?.name === 'string' ? track.name : '';
+      if (!trackName) {
+        return true;
+      }
+
+      let parsed: ReturnType<typeof PropertyBinding.parseTrackName>;
+      try {
+        parsed = PropertyBinding.parseTrackName(trackName);
+      } catch {
+        return true;
+      }
+
+      if (parsed.propertyName === 'morphTargetInfluences') {
+        return false;
+      }
+
+      if (parsed.propertyName !== 'position' && parsed.propertyName !== 'quaternion') {
+        return true;
+      }
+
+      const targetKey = parsed.objectName === 'bones' && parsed.objectIndex
+        ? parsed.objectIndex
+        : parsed.nodeName;
+      if (!targetKey) {
+        return true;
+      }
+
+      const target = model.getObjectByProperty('uuid', targetKey)
+        ?? PropertyBinding.findNode(model, targetKey);
+      if (!target || target === model || target.parent === null || (target as any).isCamera) {
+        return true;
+      }
+
+      return !safeTransformTargets.has(target);
+    });
+
+    if (unsupportedTracks.length === 0) {
+      return { supported: true };
+    }
+
+    return {
+      supported: false,
+      reason: 'unsafe_baked_additive_tracks',
+    };
+  }
+
+  private getAdditiveSupport(clipName: string, clip?: AnimationClip | null): AdditiveSupport {
+    const cached = this.additiveSupport.get(clipName);
+    if (cached) {
+      return cached;
+    }
+
+    const resolvedClip = clip ?? this.animationClips.find((entry) => entry.name === clipName);
+    if (!resolvedClip) {
+      return { supported: false };
+    }
+
+    const support = this.analyzeAdditiveSupport(resolvedClip);
+    this.additiveSupport.set(clipName, support);
+    return support;
+  }
+
+  private sanitizeBakedBlendMode(
+    clipName: string,
+    state: NormalizedPlaybackState,
+    clip?: AnimationClip | null
+  ): NormalizedPlaybackState {
+    if (state.source !== 'baked' || state.requestedBlendMode !== 'additive') {
+      return {
+        ...state,
+        blendMode: state.requestedBlendMode,
+      };
+    }
+
+    const support = this.getAdditiveSupport(clipName, clip);
+    if (support.supported) {
+      return {
+        ...state,
+        blendMode: 'additive',
+      };
+    }
+
+    console.warn(
+      `[Loom3] Baked clip "${clipName}" does not support additive playback; falling back to replace.` +
+      (support.reason ? ` ${support.reason}.` : '')
+    );
+
+    return {
+      ...state,
+      blendMode: 'replace',
+    };
   }
 
   private resolveStartTime(
@@ -439,6 +560,7 @@ export class BakedAnimationController {
     this.clipHandles.clear();
     this.clipSources.clear();
     this.playbackState.clear();
+    this.additiveSupport.clear();
   }
 
   loadAnimationClips(clips: unknown[]): void {
@@ -452,6 +574,7 @@ export class BakedAnimationController {
 
     for (const clip of this.animationClips) {
       this.clipSources.set(clip.name, 'baked');
+      this.additiveSupport.set(clip.name, this.analyzeAdditiveSupport(clip));
       if (!this.animationActions.has(clip.name) && this.animationMixer) {
         const action = this.animationMixer.clipAction(clip);
         this.animationActions.set(clip.name, action);
@@ -465,6 +588,8 @@ export class BakedAnimationController {
       duration: clip.duration,
       trackCount: clip.tracks.length,
       source: this.clipSources.get(clip.name) ?? 'baked',
+      supportsAdditive: this.getAdditiveSupport(clip.name, clip).supported,
+      additiveModeReason: this.getAdditiveSupport(clip.name, clip).reason,
     }));
   }
 
@@ -505,6 +630,7 @@ export class BakedAnimationController {
     this.animationFinishedCallbacks.delete(clipName);
     this.playbackState.delete(clipName);
     this.clipSources.delete(clipName);
+    this.additiveSupport.delete(clipName);
 
     return true;
   }
@@ -519,9 +645,13 @@ export class BakedAnimationController {
       this.setActionId(action, clipName);
     }
 
-    const playbackState = this.mergePlaybackOptions(
+    const playbackState = this.sanitizeBakedBlendMode(
+      clipName,
+      this.mergePlaybackOptions(
       this.getPlaybackStateSnapshot(clipName, { loop: true, source: 'baked' }),
       options
+      ),
+      action.getClip()
     );
     const crossfadeDuration = options.crossfadeDuration ?? 0;
     const clampWhenFinished = options.clampWhenFinished ?? playbackState.loopMode === 'once';
@@ -704,11 +834,18 @@ export class BakedAnimationController {
   setAnimationBlendMode(clipName: string, blendMode: AnimationBlendMode): void {
     const action = this.getOrCreateBakedAction(clipName);
     if (!action) return;
-    const next = this.getPlaybackStateSnapshot(clipName, {
-      loop: true,
-      source: this.clipSources.get(clipName) ?? 'baked',
-    });
-    next.blendMode = blendMode;
+    const next = this.sanitizeBakedBlendMode(
+      clipName,
+      {
+        ...this.getPlaybackStateSnapshot(clipName, {
+          loop: true,
+          source: this.clipSources.get(clipName) ?? 'baked',
+        }),
+        requestedBlendMode: blendMode,
+        blendMode,
+      },
+      action.getClip()
+    );
     this.applyPlaybackState(action, next);
     this.setPlaybackState(clipName, next);
   }
@@ -735,6 +872,7 @@ export class BakedAnimationController {
 
     const clip = action.getClip();
     const state = this.playbackState.get(clipName);
+    const additiveSupport = this.getAdditiveSupport(clipName, clip);
     const loopMode = state?.loopMode
       ?? (action.loop === LoopPingPong ? 'pingpong' : action.loop === LoopOnce ? 'once' : 'repeat');
     const playbackRate = state?.playbackRate ?? Math.abs(action.getEffectiveTimeScale());
@@ -752,7 +890,10 @@ export class BakedAnimationController {
       reverse,
       weight: state?.weight ?? action.getEffectiveWeight(),
       balance: state?.balance ?? 0,
+      requestedBlendMode: state?.requestedBlendMode ?? state?.blendMode ?? 'replace',
       blendMode: state?.blendMode ?? 'replace',
+      supportsAdditive: additiveSupport.supported,
+      additiveModeReason: additiveSupport.reason,
       easing: state?.easing ?? 'linear',
       loop: loopMode !== 'once',
       loopMode,


### PR DESCRIPTION
Closes #105.

## What changed
- classify baked clips for additive safety instead of blindly flipping the Three.js action blend mode
- allow additive only for morph tracks and resolved runtime bone transforms
- force unsafe baked additive requests back to `replace`
- expose requested vs effective blend-mode state through `requestedBlendMode`, `supportsAdditive`, and `additiveModeReason`
- add playback-state tests for safe head-bone additive playback and unsafe root-transform fallback

## Why
Baked additive playback was treating the full authored clip as additive, which let camera/root/global or otherwise unresolved transform tracks leak into layering scenarios that should stay face/head-focused.

## Paired Testing
- Loom3 runtime PR: https://github.com/meekmachine/Loom3/pull/107
- LoomLarge frontend PR: https://github.com/meekmachine/LoomLarge/pull/339

## Validation
- `npm test -- AnimationThree.playbackState.test.ts`
- `npm run typecheck`