### PR TITLE
[codex] Add annotation authoring helpers

### DIFF
--- a/ANNOTATION_CONFIGURATION.md
+++ b/ANNOTATION_CONFIGURATION.md
@@ -1,14 +1,13 @@
 # Annotation Configuration
 
-Loom3 exposes annotation configuration through `annotationRegions` on `Profile`, but the current LoomLarge demo/runtime still reads top-level `CharacterConfig.regions` as the live source of truth.
+Loom3 exposes annotation configuration through `annotationRegions` on `Profile`.
 
-> Note
-> Annotations have not been moved from the demo project into Loom3 yet, but we plan to move them soon.
+For authoring and persistence, **treat `annotationRegions` as the canonical Loom3 shape**.
 
-This means there are two related shapes to know about:
+The current LoomLarge runtime still reads top-level `CharacterConfig.regions` as its live source of truth, so there are still two related shapes to understand:
 
-1. The Loom3 profile shape: `profile.annotationRegions`
-2. The current LoomLarge runtime shape: `config.regions`
+1. The canonical authored shape: `profile.annotationRegions`
+2. The current runtime/back-compat shape: `config.regions`
 
 ## Current Runtime Truth
 
@@ -58,6 +57,20 @@ export const HUMAN_ANNOTATION_OVERRIDES: Partial<Profile> = {
 
 `extendPresetWithProfile()` merges `annotationRegions` by region name, so a profile can override just the fields it needs without copying the full preset region array.
 
+If you are working with a full saved `CharacterConfig`, prefer `extendCharacterConfigWithPreset(...)` to build the runtime `regions` shape from the canonical authored annotation config.
+
+Loom3 also exports package-side annotation authoring helpers:
+
+```ts
+import {
+  mergeAnnotationRegionsByName,
+  removeAnnotationRegionByName,
+  reorderAnnotationRegions,
+  resetAnnotationRegionByName,
+  validateAnnotationRegions,
+} from '@lovelace_lol/loom3';
+```
+
 ## Region Fields
 
 Each annotation region supports these fields:
@@ -102,6 +115,7 @@ interface AnnotationRegion {
   };
   groupId?: string;
   isFallback?: boolean;
+  customPosition?: { x: number; y: number; z: number };
 }
 ```
 
@@ -144,6 +158,14 @@ Final additive offset applied after the camera position is computed.
 - Do not use it as a replacement for semantic left/right camera behavior.
 - In the current runtime it is applied in world space, not in model-local space.
 
+### `customPosition`
+
+Explicit world-space anchor override for the region.
+
+- If set, runtime marker systems can use it instead of a derived geometry center.
+- This is useful when automatic geometry resolution is close but not exact.
+- Because it is explicit authoring data, prefer storing it on `annotationRegions` rather than inventing an app-only side channel.
+
 ## Marker Fields
 
 These fields affect marker presentation, not camera framing:
@@ -182,6 +204,18 @@ Use this when the visible annotation surface is better described by mesh geometr
 
 General object targets. `['*']` means the whole model.
 
+## Region suppression
+
+Profiles can also carry:
+
+```ts
+disabledRegions?: string[];
+```
+
+Use this when a preset region should be suppressed for a specific character while preserving the rest of the preset region tree.
+
+`extendCharacterConfigWithPreset(...)` applies `disabledRegions` through `normalizeRegionTree(...)`, which removes disabled regions and repairs parent/child links in the effective runtime region list.
+
 ## Recommended Authoring Pattern
 
 For common behavior shared by a preset:
@@ -191,8 +225,47 @@ For common behavior shared by a preset:
 
 For the current LoomLarge runtime:
 
-1. Put the active camera/marker settings in top-level `config.regions`.
-2. Treat `profile.annotationRegions` as the intended Loom3-native shape, not the currently consumed demo-app source of truth.
+1. Author and persist the intended camera/marker settings in `profile.annotationRegions`.
+2. Use `extendCharacterConfigWithPreset(...)` to materialize the effective runtime `config.regions` shape.
+3. Treat direct writes to top-level `config.regions` as a runtime/back-compat path, not the preferred authored source of truth.
+
+## Helper usage examples
+
+### Merge an edited region into authored annotation overrides
+
+```ts
+const nextRegions = mergeAnnotationRegionsByName(profile.annotationRegions, [
+  {
+    name: 'left_eye',
+    cameraAngle: 45,
+    customPosition: { x: 0.02, y: 1.61, z: 0.11 },
+  },
+]);
+```
+
+### Remove a custom region override
+
+```ts
+const nextRegions = removeAnnotationRegionByName(profile.annotationRegions, 'visor');
+```
+
+### Restore one region back to preset defaults
+
+```ts
+const resetRegions = resetAnnotationRegionByName(
+  profile.annotationRegions,
+  preset.annotationRegions,
+  'left_eye',
+);
+```
+
+### Validate annotation authoring data before saving
+
+```ts
+const issues = validateAnnotationRegions(profile.annotationRegions, {
+  disabledRegions: profile.disabledRegions,
+});
+```
 
 ## Example: Eye Closeup
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,21 @@ const loom = new Loom3({
 
 `annotationRegions` is the Loom3 field for camera/marker region defaults and profile overrides.
 
+For authoring and persistence, treat `annotationRegions` as the canonical Loom3 surface. Top-level `CharacterConfig.regions` remains the runtime/back-compat shape consumed by the current LoomLarge camera stack.
+
+Loom3 now also exports package-side annotation helpers so downstream editors do not need to duplicate region merge or validation logic:
+
+```typescript
+import {
+  extendCharacterConfigWithPreset,
+  mergeAnnotationRegionsByName,
+  removeAnnotationRegionByName,
+  reorderAnnotationRegions,
+  resetAnnotationRegionByName,
+  validateAnnotationRegions,
+} from '@lovelace_lol/loom3';
+```
+
 If your app fetches a full saved `CharacterConfig` from Firestore or another backend, use `extendCharacterConfigWithPreset(...)` to build the runtime shape before handing that config to camera/marker tooling:
 
 ```typescript
@@ -359,14 +374,32 @@ const savedConfig = await fetchCharacterConfig();
 const runtimeConfig = extendCharacterConfigWithPreset(savedConfig);
 ```
 
+If you need to patch or validate annotation authoring data before saving it, prefer the shared helpers over ad hoc app-side merge code:
+
+```typescript
+const nextRegions = mergeAnnotationRegionsByName(savedProfile.annotationRegions, [
+  {
+    name: 'left_eye',
+    cameraAngle: 45,
+    customPosition: { x: 0.02, y: 1.61, z: 0.11 },
+  },
+]);
+
+const issues = validateAnnotationRegions(nextRegions, {
+  disabledRegions: savedProfile.disabledRegions,
+});
+```
+
 For the current runtime-oriented documentation, including:
 
 - `paddingFactor`
 - `cameraAngle`
 - `cameraOffset`
+- `customPosition`
+- `disabledRegions`
 - `style.lineDirection`
 - the difference between `cameraAngle: 0` and omitting `cameraAngle`
-- the current LoomLarge runtime note that annotations have not been moved from the demo project into Loom3 yet
+- the current LoomLarge runtime compatibility note around top-level `regions`
 
 see [ANNOTATION_CONFIGURATION.md](./ANNOTATION_CONFIGURATION.md).
 

--- a/src/characters/extendCharacterConfigWithPreset.test.ts
+++ b/src/characters/extendCharacterConfigWithPreset.test.ts
@@ -194,6 +194,26 @@ describe('extendCharacterConfigWithPreset', () => {
     });
   });
 
+  it('preserves explicit custom annotation positions through preset extension', () => {
+    const extended = extendCharacterConfigWithPreset(
+      createConfig({
+        regions: [
+          {
+            name: 'left_eye',
+            customPosition: { x: 1, y: 2, z: 3 },
+          },
+        ],
+      })
+    );
+
+    expect(extended.regions.find((region) => region.name === 'left_eye')).toMatchObject({
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      parent: 'head',
+      customPosition: { x: 1, y: 2, z: 3 },
+    });
+  });
+
   it('drops disabled preset regions after extension and cleans parent-child links', () => {
     const extended = extendCharacterConfigWithPreset(
       createConfig({
@@ -364,6 +384,26 @@ describe('extractProfileOverrides', () => {
     });
     expect(overrides.disabledRegions).toEqual(['mouth']);
     expect(overrides.annotationRegions).toBeUndefined();
+  });
+
+  it('extracts top-level regions as canonical annotation profile overrides including customPosition', () => {
+    const overrides = extractProfileOverrides(
+      createConfig({
+        regions: [
+          {
+            name: 'left_eye',
+            customPosition: { x: 1, y: 2, z: 3 },
+          },
+        ],
+      })
+    );
+
+    expect(overrides.annotationRegions).toEqual([
+      {
+        name: 'left_eye',
+        customPosition: { x: 1, y: 2, z: 3 },
+      },
+    ]);
   });
 });
 

--- a/src/characters/extendCharacterConfigWithPreset.ts
+++ b/src/characters/extendCharacterConfigWithPreset.ts
@@ -1,6 +1,10 @@
 import type { Profile } from '../mappings/types';
 import { extendPresetWithProfile } from '../mappings/extendPresetWithProfile';
 import { getPreset } from '../presets';
+import {
+  cloneAnnotationRegion,
+  mergeAnnotationRegionsByName,
+} from '../regions/annotationRegions';
 import { normalizeRegionTree } from '../regions/normalizeRegionTree';
 import type { CharacterConfig, Region } from './types';
 
@@ -39,10 +43,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function cloneArray<T>(value: T[] | undefined): T[] | undefined {
-  return value ? value.map((entry) => cloneValue(entry) as T) : undefined;
-}
-
 function cloneValue<T>(value: T): T {
   if (Array.isArray(value)) {
     return value.map((entry) => cloneValue(entry)) as T;
@@ -76,80 +76,8 @@ function mergeProfileOverrideValue<T>(base: T | undefined, override: T | undefin
   return cloneValue(override);
 }
 
-function cloneVector3(
-  value?: { x?: number; y?: number; z?: number }
-): { x?: number; y?: number; z?: number } | undefined {
-  return value ? { ...value } : undefined;
-}
-
-function cloneRegion(region: Region): Region {
-  return {
-    ...region,
-    bones: cloneArray(region.bones),
-    meshes: cloneArray(region.meshes),
-    objects: cloneArray(region.objects),
-    children: cloneArray(region.children),
-    cameraOffset: cloneVector3(region.cameraOffset),
-    customPosition: region.customPosition ? { ...region.customPosition } : undefined,
-    style: region.style
-      ? {
-          ...region.style,
-          line: region.style.line ? { ...region.style.line } : undefined,
-        }
-      : undefined,
-  };
-}
-
-function mergeRegion(base: Region, override: Region): Region {
-  return {
-    ...base,
-    ...override,
-    bones: override.bones !== undefined ? [...override.bones] : base.bones ? [...base.bones] : undefined,
-    meshes: override.meshes !== undefined ? [...override.meshes] : base.meshes ? [...base.meshes] : undefined,
-    objects: override.objects !== undefined ? [...override.objects] : base.objects ? [...base.objects] : undefined,
-    children: override.children !== undefined ? [...override.children] : base.children ? [...base.children] : undefined,
-    cameraOffset: override.cameraOffset
-      ? { ...base.cameraOffset, ...override.cameraOffset }
-      : cloneVector3(base.cameraOffset),
-    customPosition: override.customPosition
-      ? { ...override.customPosition }
-      : base.customPosition
-        ? { ...base.customPosition }
-        : undefined,
-    style: override.style
-      ? {
-          ...base.style,
-          ...override.style,
-          line: override.style.line
-            ? { ...base.style?.line, ...override.style.line }
-            : base.style?.line
-              ? { ...base.style.line }
-              : undefined,
-        }
-      : base.style
-        ? {
-            ...base.style,
-            line: base.style.line ? { ...base.style.line } : undefined,
-          }
-        : undefined,
-  };
-}
-
 export function mergeRegionsByName(base?: Region[], override?: Region[]): Region[] | undefined {
-  if (!base && !override) return undefined;
-
-  const merged = new Map<string, Region>();
-
-  for (const region of base ?? []) {
-    merged.set(region.name, cloneRegion(region));
-  }
-
-  for (const region of override ?? []) {
-    const existing = merged.get(region.name);
-    merged.set(region.name, existing ? mergeRegion(existing, region) : cloneRegion(region));
-  }
-
-  return Array.from(merged.values());
+  return mergeAnnotationRegionsByName(base, override);
 }
 
 export function extractProfileOverrides(config: CharacterConfig): Partial<Profile> {
@@ -174,7 +102,7 @@ export function extractProfileOverrides(config: CharacterConfig): Partial<Profil
       );
 
       if (regions) {
-        overrides.annotationRegions = regions.map((region) => cloneRegion(region));
+        overrides.annotationRegions = regions.map((region) => cloneAnnotationRegion(region));
       }
       continue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,21 @@ export {
   resolveFaceCenter,
 } from './regions/regionMapping';
 
+export type {
+  AnnotationValidationCode,
+  AnnotationValidationIssue,
+} from './regions/annotationRegions';
+
+export {
+  cloneAnnotationRegion,
+  mergeAnnotationRegionsByName,
+  mergeAnnotationRegion,
+  removeAnnotationRegionByName,
+  reorderAnnotationRegions,
+  resetAnnotationRegionByName,
+  validateAnnotationRegions,
+} from './regions/annotationRegions';
+
 // ============================================================================
 // PRESETS
 // ============================================================================

--- a/src/mappings/extendPresetWithProfile.test.ts
+++ b/src/mappings/extendPresetWithProfile.test.ts
@@ -37,7 +37,7 @@ describe('extendPresetWithProfile', () => {
   it('merges annotation regions by name', () => {
     const result = extendPresetWithProfile(basePreset, {
       annotationRegions: [
-        { name: 'face', meshes: ['FaceMesh2'], paddingFactor: 1.5 },
+        { name: 'face', meshes: ['FaceMesh2'], paddingFactor: 1.5, customPosition: { x: 1, y: 2, z: 3 } },
         { name: 'mouth', bones: ['Jaw'] },
       ],
     });
@@ -48,6 +48,7 @@ describe('extendPresetWithProfile', () => {
     expect(face?.meshes).toEqual(['FaceMesh2']);
     expect(face?.bones).toEqual(['Head']);
     expect(face?.paddingFactor).toBe(1.5);
+    expect(face?.customPosition).toEqual({ x: 1, y: 2, z: 3 });
     expect(mouth?.bones).toEqual(['Jaw']);
   });
 

--- a/src/mappings/extendPresetWithProfile.ts
+++ b/src/mappings/extendPresetWithProfile.ts
@@ -1,4 +1,5 @@
 import type { Profile, AnnotationRegion, HairPhysicsProfileConfig } from './types';
+import { mergeAnnotationRegionsByName } from '../regions/annotationRegions';
 
 type RecordValue = string | number | boolean | object | null | undefined;
 type RecordKey = string | number;
@@ -36,60 +37,6 @@ const mergeRecord = <K extends RecordKey, T extends RecordValue>(
   }
 
   return next;
-};
-
-const mergeAnnotationRegion = (
-  base: AnnotationRegion,
-  override: AnnotationRegion
-): AnnotationRegion => {
-  const merged: AnnotationRegion = {
-    ...base,
-    ...override,
-  };
-
-  merged.bones = override.bones ? [...override.bones] : base.bones ? [...base.bones] : undefined;
-  merged.meshes = override.meshes ? [...override.meshes] : base.meshes ? [...base.meshes] : undefined;
-  merged.objects = override.objects ? [...override.objects] : base.objects ? [...base.objects] : undefined;
-  merged.children = override.children ? [...override.children] : base.children ? [...base.children] : undefined;
-  merged.cameraOffset = override.cameraOffset
-    ? { ...override.cameraOffset }
-    : base.cameraOffset
-      ? { ...base.cameraOffset }
-      : undefined;
-  merged.style = override.style
-    ? {
-        ...base.style,
-        ...override.style,
-        line: override.style.line
-          ? { ...base.style?.line, ...override.style.line }
-          : base.style?.line
-            ? { ...base.style.line }
-            : undefined,
-      }
-    : base.style
-      ? { ...base.style, line: base.style.line ? { ...base.style.line } : undefined }
-      : undefined;
-
-  return merged;
-};
-
-const mergeAnnotationRegions = (
-  base?: AnnotationRegion[],
-  override?: AnnotationRegion[]
-): AnnotationRegion[] | undefined => {
-  if (!base && !override) return undefined;
-  if (!base) return override ? override.map((region) => mergeAnnotationRegion(region, region)) : undefined;
-  const regionMap = new Map<string, AnnotationRegion>();
-  for (const region of base) {
-    regionMap.set(region.name, mergeAnnotationRegion(region, region));
-  }
-  if (override) {
-    for (const region of override) {
-      const existing = regionMap.get(region.name);
-      regionMap.set(region.name, existing ? mergeAnnotationRegion(existing, region) : mergeAnnotationRegion(region, region));
-    }
-  }
-  return Array.from(regionMap.values());
 };
 
 const mergeHairPhysicsConfig = (
@@ -181,7 +128,7 @@ export function extendPresetWithProfile(base: Profile, extension?: Partial<Profi
     continuumLabels: base.continuumLabels || extension.continuumLabels
       ? mergeRecord(base.continuumLabels || {}, extension.continuumLabels || {})
       : undefined,
-    annotationRegions: mergeAnnotationRegions(base.annotationRegions, extension.annotationRegions),
+    annotationRegions: mergeAnnotationRegionsByName(base.annotationRegions, extension.annotationRegions),
     disabledRegions,
     hairPhysics: mergeHairPhysicsConfig(base.hairPhysics, extension.hairPhysics),
   };

--- a/src/mappings/types.ts
+++ b/src/mappings/types.ts
@@ -249,6 +249,11 @@ export interface AnnotationRegion {
   };
   groupId?: string;
   isFallback?: boolean;
+  customPosition?: {
+    x: number;
+    y: number;
+    z: number;
+  };
 }
 
 /**

--- a/src/regions/annotationRegions.test.ts
+++ b/src/regions/annotationRegions.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import type { AnnotationRegion } from '../mappings/types';
+import {
+  cloneAnnotationRegion,
+  mergeAnnotationRegionsByName,
+  removeAnnotationRegionByName,
+  reorderAnnotationRegions,
+  resetAnnotationRegionByName,
+  validateAnnotationRegions,
+} from './annotationRegions';
+
+describe('annotationRegions helpers', () => {
+  it('deep-clones nested annotation region fields', () => {
+    const original: AnnotationRegion = {
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      cameraOffset: { x: 1 },
+      customPosition: { x: 1, y: 2, z: 3 },
+      style: {
+        lineDirection: 'camera',
+        line: { thickness: 2 },
+      },
+    };
+
+    const cloned = cloneAnnotationRegion(original);
+    cloned.bones?.push('EXTRA');
+    cloned.cameraOffset!.x = 4;
+    cloned.customPosition!.x = 9;
+    cloned.style!.line!.thickness = 5;
+
+    expect(original).toEqual({
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      cameraOffset: { x: 1 },
+      customPosition: { x: 1, y: 2, z: 3 },
+      style: {
+        lineDirection: 'camera',
+        line: { thickness: 2 },
+      },
+    });
+  });
+
+  it('merges annotation regions by name including customPosition', () => {
+    const merged = mergeAnnotationRegionsByName(
+      [
+        {
+          name: 'face',
+          bones: ['HEAD'],
+          style: { opacity: 0.5, line: { thickness: 2 } },
+        },
+      ],
+      [
+        {
+          name: 'face',
+          cameraAngle: 45,
+          customPosition: { x: 1, y: 2, z: 3 },
+          style: { lineDirection: 'camera', line: { length: 0.2 } },
+        },
+      ]
+    );
+
+    expect(merged).toEqual([
+      {
+        name: 'face',
+        bones: ['HEAD'],
+        cameraAngle: 45,
+        customPosition: { x: 1, y: 2, z: 3 },
+        style: {
+          opacity: 0.5,
+          lineDirection: 'camera',
+          line: {
+            thickness: 2,
+            length: 0.2,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('removes, reorders, and resets annotation regions against a base preset list', () => {
+    const base: AnnotationRegion[] = [
+      { name: 'head', bones: ['HEAD'] },
+      { name: 'left_eye', bones: ['EYE_L'], parent: 'head' },
+      { name: 'right_eye', bones: ['EYE_R'], parent: 'head' },
+    ];
+    const current: AnnotationRegion[] = [
+      { name: 'visor', objects: ['VisorMesh'] },
+      { name: 'left_eye', bones: ['CUSTOM_EYE'], cameraAngle: 45 },
+      { name: 'head', bones: ['CUSTOM_HEAD'] },
+    ];
+
+    const removed = removeAnnotationRegionByName(current, 'visor');
+    expect(removed?.map((region) => region.name)).toEqual(['left_eye', 'head']);
+
+    const reordered = reorderAnnotationRegions(current, ['head', 'left_eye']);
+    expect(reordered?.map((region) => region.name)).toEqual(['head', 'left_eye', 'visor']);
+
+    const resetExisting = resetAnnotationRegionByName(current, base, 'left_eye');
+    expect(resetExisting?.find((region) => region.name === 'left_eye')).toEqual({
+      name: 'left_eye',
+      bones: ['EYE_L'],
+      parent: 'head',
+    });
+
+    const resetMissingToBase = resetAnnotationRegionByName(current, base, 'right_eye');
+    expect(resetMissingToBase?.map((region) => region.name)).toEqual(['visor', 'left_eye', 'head', 'right_eye']);
+    expect(resetMissingToBase?.find((region) => region.name === 'right_eye')).toEqual({
+      name: 'right_eye',
+      bones: ['EYE_R'],
+      parent: 'head',
+    });
+
+    const resetCustomOnly = resetAnnotationRegionByName(current, base, 'visor');
+    expect(resetCustomOnly?.map((region) => region.name)).toEqual(['left_eye', 'head']);
+  });
+
+  it('validates duplicate names, hierarchy problems, invalid vectors, and unknown disabled regions', () => {
+    const issues = validateAnnotationRegions(
+      [
+        {
+          name: 'head',
+          children: ['left_eye', 'missing_child'],
+        },
+        {
+          name: 'left_eye',
+          parent: 'face',
+          style: {
+            lineDirection: { x: 1, y: Number.NaN, z: 0 },
+          },
+        },
+        {
+          name: 'loop_a',
+          children: ['loop_b'],
+        },
+        {
+          name: 'loop_b',
+          parent: 'loop_a',
+          children: ['loop_a'],
+          customPosition: { x: 1, y: 2, z: Number.POSITIVE_INFINITY },
+        },
+        {
+          name: 'fallback_marker',
+          isFallback: true,
+        },
+        {
+          name: 'head',
+          cameraOffset: { x: Number.NaN },
+        },
+      ],
+      { disabledRegions: ['mouth'] }
+    );
+
+    expect(issues.map((issue) => issue.code)).toEqual(expect.arrayContaining([
+      'duplicate-region-name',
+      'missing-parent',
+      'missing-child',
+      'inconsistent-parent-child',
+      'cycle-detected',
+      'invalid-camera-offset',
+      'invalid-custom-position',
+      'invalid-line-direction',
+      'fallback-without-group',
+      'unknown-disabled-region',
+    ]));
+  });
+
+  it('returns no issues for a valid annotation region tree', () => {
+    const issues = validateAnnotationRegions(
+      [
+        {
+          name: 'head',
+          children: ['left_eye'],
+        },
+        {
+          name: 'left_eye',
+          parent: 'head',
+          customPosition: { x: 1, y: 2, z: 3 },
+          style: {
+            lineDirection: { x: 0, y: 1, z: 0 },
+          },
+          groupId: 'eyes',
+        },
+      ],
+      { disabledRegions: ['left_eye'] }
+    );
+
+    expect(issues).toEqual([]);
+  });
+});

--- a/src/regions/annotationRegions.ts
+++ b/src/regions/annotationRegions.ts
@@ -1,0 +1,361 @@
+import type { AnnotationRegion } from '../mappings/types';
+
+type AnnotationVector = { x?: number; y?: number; z?: number };
+type AnnotationPoint = { x: number; y: number; z: number };
+
+export type AnnotationValidationCode =
+  | 'duplicate-region-name'
+  | 'missing-parent'
+  | 'missing-child'
+  | 'inconsistent-parent-child'
+  | 'cycle-detected'
+  | 'unknown-disabled-region'
+  | 'invalid-camera-offset'
+  | 'invalid-custom-position'
+  | 'invalid-line-direction'
+  | 'fallback-without-group';
+
+export interface AnnotationValidationIssue {
+  code: AnnotationValidationCode;
+  message: string;
+  regionName?: string;
+  relatedRegionName?: string;
+}
+
+function cloneStringArray(value?: string[]): string[] | undefined {
+  return value ? [...value] : undefined;
+}
+
+function cloneVector3(value?: AnnotationVector): AnnotationVector | undefined {
+  return value ? { ...value } : undefined;
+}
+
+function clonePoint3(value?: AnnotationPoint): AnnotationPoint | undefined {
+  return value ? { ...value } : undefined;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isFiniteVector3(
+  value: AnnotationVector | undefined,
+  requiredKeys: ReadonlyArray<'x' | 'y' | 'z'>
+): boolean {
+  if (!value) return false;
+
+  return requiredKeys.every((key) => isFiniteNumber(value[key]));
+}
+
+function getChildGraph(regions: AnnotationRegion[]): Map<string, Set<string>> {
+  const graph = new Map<string, Set<string>>();
+
+  for (const region of regions) {
+    if (!graph.has(region.name)) {
+      graph.set(region.name, new Set());
+    }
+  }
+
+  for (const region of regions) {
+    const children = graph.get(region.name)!;
+
+    for (const child of region.children ?? []) {
+      children.add(child);
+    }
+
+    if (region.parent) {
+      const parentChildren = graph.get(region.parent) ?? new Set<string>();
+      parentChildren.add(region.name);
+      graph.set(region.parent, parentChildren);
+    }
+  }
+
+  return graph;
+}
+
+export function cloneAnnotationRegion<T extends AnnotationRegion>(region: T): T {
+  return {
+    ...region,
+    bones: cloneStringArray(region.bones),
+    meshes: cloneStringArray(region.meshes),
+    objects: cloneStringArray(region.objects),
+    children: cloneStringArray(region.children),
+    cameraOffset: cloneVector3(region.cameraOffset),
+    customPosition: clonePoint3(region.customPosition),
+    style: region.style
+      ? {
+          ...region.style,
+          line: region.style.line ? { ...region.style.line } : undefined,
+        }
+      : undefined,
+  };
+}
+
+export function mergeAnnotationRegion<T extends AnnotationRegion>(base: T, override: T): T {
+  return {
+    ...base,
+    ...override,
+    bones: override.bones !== undefined ? [...override.bones] : base.bones ? [...base.bones] : undefined,
+    meshes: override.meshes !== undefined ? [...override.meshes] : base.meshes ? [...base.meshes] : undefined,
+    objects: override.objects !== undefined ? [...override.objects] : base.objects ? [...base.objects] : undefined,
+    children: override.children !== undefined ? [...override.children] : base.children ? [...base.children] : undefined,
+    cameraOffset: override.cameraOffset
+      ? { ...base.cameraOffset, ...override.cameraOffset }
+      : cloneVector3(base.cameraOffset),
+    customPosition: override.customPosition
+      ? { ...override.customPosition }
+      : base.customPosition
+        ? { ...base.customPosition }
+        : undefined,
+    style: override.style
+      ? {
+          ...base.style,
+          ...override.style,
+          line: override.style.line
+            ? { ...base.style?.line, ...override.style.line }
+            : base.style?.line
+              ? { ...base.style.line }
+              : undefined,
+        }
+      : base.style
+        ? {
+            ...base.style,
+            line: base.style.line ? { ...base.style.line } : undefined,
+          }
+        : undefined,
+  };
+}
+
+export function mergeAnnotationRegionsByName<T extends AnnotationRegion>(
+  base?: T[],
+  override?: T[]
+): T[] | undefined {
+  if (!base && !override) return undefined;
+
+  const merged = new Map<string, T>();
+
+  for (const region of base ?? []) {
+    merged.set(region.name, cloneAnnotationRegion(region));
+  }
+
+  for (const region of override ?? []) {
+    const existing = merged.get(region.name);
+    merged.set(region.name, existing ? mergeAnnotationRegion(existing, region) : cloneAnnotationRegion(region));
+  }
+
+  return Array.from(merged.values());
+}
+
+export function removeAnnotationRegionByName<T extends AnnotationRegion>(
+  regions: T[] | undefined,
+  regionName: string
+): T[] | undefined {
+  if (!regions) return undefined;
+
+  return regions
+    .filter((region) => region.name !== regionName)
+    .map((region) => cloneAnnotationRegion(region));
+}
+
+export function reorderAnnotationRegions<T extends AnnotationRegion>(
+  regions: T[] | undefined,
+  orderedNames: readonly string[]
+): T[] | undefined {
+  if (!regions) return undefined;
+
+  const regionMap = new Map(regions.map((region) => [region.name, cloneAnnotationRegion(region)]));
+  const seen = new Set<string>();
+  const next: T[] = [];
+
+  for (const name of orderedNames) {
+    const region = regionMap.get(name);
+    if (!region || seen.has(name)) continue;
+    seen.add(name);
+    next.push(region);
+  }
+
+  for (const region of regions) {
+    if (seen.has(region.name)) continue;
+    seen.add(region.name);
+    next.push(cloneAnnotationRegion(region));
+  }
+
+  return next;
+}
+
+export function resetAnnotationRegionByName<T extends AnnotationRegion>(
+  regions: T[] | undefined,
+  baseRegions: T[] | undefined,
+  regionName: string
+): T[] | undefined {
+  const current = regions ?? [];
+  const baseRegion = baseRegions?.find((region) => region.name === regionName);
+  const currentIndex = current.findIndex((region) => region.name === regionName);
+
+  if (!baseRegion) {
+    return removeAnnotationRegionByName(current, regionName);
+  }
+
+  const next = current.map((region) => cloneAnnotationRegion(region));
+  if (currentIndex >= 0) {
+    next[currentIndex] = cloneAnnotationRegion(baseRegion);
+    return next;
+  }
+
+  next.push(cloneAnnotationRegion(baseRegion));
+  return next;
+}
+
+export function validateAnnotationRegions(
+  regions?: AnnotationRegion[],
+  options?: { disabledRegions?: string[] }
+): AnnotationValidationIssue[] {
+  if (!regions || regions.length === 0) return [];
+
+  const issues: AnnotationValidationIssue[] = [];
+  const counts = new Map<string, number>();
+
+  for (const region of regions) {
+    counts.set(region.name, (counts.get(region.name) ?? 0) + 1);
+  }
+
+  const duplicateNames = new Set(
+    Array.from(counts.entries())
+      .filter(([, count]) => count > 1)
+      .map(([name]) => name)
+  );
+
+  for (const name of duplicateNames) {
+    issues.push({
+      code: 'duplicate-region-name',
+      regionName: name,
+      message: `Annotation region "${name}" is defined more than once.`,
+    });
+  }
+
+  for (const region of regions) {
+    if (region.cameraOffset) {
+      const invalidCameraOffset = ['x', 'y', 'z'].some((key) => {
+        const value = region.cameraOffset?.[key as keyof AnnotationVector];
+        return value !== undefined && !isFiniteNumber(value);
+      });
+      if (invalidCameraOffset) {
+        issues.push({
+          code: 'invalid-camera-offset',
+          regionName: region.name,
+          message: `Annotation region "${region.name}" has a non-finite cameraOffset value.`,
+        });
+      }
+    }
+
+    if (region.customPosition && !isFiniteVector3(region.customPosition, ['x', 'y', 'z'])) {
+      issues.push({
+        code: 'invalid-custom-position',
+        regionName: region.name,
+        message: `Annotation region "${region.name}" has an invalid customPosition vector.`,
+      });
+    }
+
+    const explicitLineDirection = region.style?.lineDirection;
+    if (
+      explicitLineDirection &&
+      typeof explicitLineDirection === 'object' &&
+      !isFiniteVector3(explicitLineDirection, ['x', 'y', 'z'])
+    ) {
+      issues.push({
+        code: 'invalid-line-direction',
+        regionName: region.name,
+        message: `Annotation region "${region.name}" has an invalid explicit lineDirection vector.`,
+      });
+    }
+
+    if (region.isFallback && !region.groupId) {
+      issues.push({
+        code: 'fallback-without-group',
+        regionName: region.name,
+        message: `Annotation region "${region.name}" is marked as a fallback but has no groupId.`,
+      });
+    }
+  }
+
+  const uniqueRegions = regions.filter((region, index) => regions.findIndex((entry) => entry.name === region.name) === index);
+  const regionMap = new Map(uniqueRegions.map((region) => [region.name, region]));
+
+  for (const region of uniqueRegions) {
+    if (region.parent && !regionMap.has(region.parent)) {
+      issues.push({
+        code: 'missing-parent',
+        regionName: region.name,
+        relatedRegionName: region.parent,
+        message: `Annotation region "${region.name}" references missing parent "${region.parent}".`,
+      });
+    }
+
+    for (const childName of region.children ?? []) {
+      const child = regionMap.get(childName);
+      if (!child) {
+        issues.push({
+          code: 'missing-child',
+          regionName: region.name,
+          relatedRegionName: childName,
+          message: `Annotation region "${region.name}" references missing child "${childName}".`,
+        });
+        continue;
+      }
+
+      if (child.parent !== region.name) {
+        issues.push({
+          code: 'inconsistent-parent-child',
+          regionName: region.name,
+          relatedRegionName: childName,
+          message: `Annotation region "${region.name}" lists "${childName}" as a child, but the child points to "${child.parent ?? 'no parent'}".`,
+        });
+      }
+    }
+  }
+
+  const graph = getChildGraph(uniqueRegions);
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (name: string, path: string[]) => {
+    if (visiting.has(name)) {
+      const cycleStart = path.indexOf(name);
+      const cyclePath = cycleStart >= 0 ? path.slice(cycleStart).concat(name) : path.concat(name);
+      issues.push({
+        code: 'cycle-detected',
+        regionName: name,
+        message: `Annotation region hierarchy contains a cycle: ${cyclePath.join(' -> ')}.`,
+      });
+      return;
+    }
+
+    if (visited.has(name)) return;
+    visiting.add(name);
+    const nextPath = [...path, name];
+    for (const childName of graph.get(name) ?? []) {
+      if (regionMap.has(childName)) {
+        visit(childName, nextPath);
+      }
+    }
+    visiting.delete(name);
+    visited.add(name);
+  };
+
+  for (const name of graph.keys()) {
+    visit(name, []);
+  }
+
+  const knownNames = new Set(uniqueRegions.map((region) => region.name));
+  for (const disabledName of options?.disabledRegions ?? []) {
+    if (!knownNames.has(disabledName)) {
+      issues.push({
+        code: 'unknown-disabled-region',
+        relatedRegionName: disabledName,
+        message: `disabledRegions references unknown annotation region "${disabledName}".`,
+      });
+    }
+  }
+
+  return issues;
+}


### PR DESCRIPTION
Closes #109.

## Summary
- add shared annotation authoring helpers for cloning, merging, removing, reordering, resetting, and validating annotation regions
- make `AnnotationRegion` support persisted `customPosition` so the profile-level authoring shape matches the runtime region behavior more closely
- refactor the preset/profile and character-config extenders to reuse the shared annotation merge logic instead of keeping duplicate implementations
- document `annotationRegions` as the canonical authored annotation surface while keeping top-level `regions` as the current runtime/back-compat shape

## Why
The package already had most of the annotation data model and runtime extension path, but downstream apps still had to duplicate annotation merge and validation behavior in app code.

This change gives the SliderDrawer-side annotation editor work a package-level contract to build against and removes duplicate merge logic from the existing Loom3 extension helpers.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`