### PR TITLE
[codex] Add FBX retarget import API

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -154,6 +154,25 @@ export interface AnimationPlayOptions {
   source?: AnimationSource;
 }
 
+/** Supported input types for FBX animation import. */
+export type FBXAnimationInput = ArrayBuffer | ArrayBufferView | Blob;
+
+/** Options for importing and retargeting baked animation clips from an FBX file. */
+export interface FBXAnimationImportOptions {
+  /** Append to the existing baked clip registry (default: true). */
+  append?: boolean;
+  /** Optional override for the imported clip name. */
+  clipName?: string;
+  /** Optional sampling rate override passed into Three.js retargeting. */
+  fps?: number;
+  /** Keep root/hip locomotion instead of forcing the clip to play in place. */
+  inPlace?: boolean;
+  /** Preserve first-frame hip offset when retargeting (default: false). */
+  useFirstFramePosition?: boolean;
+  /** Optional custom resolver from target bone name -> source bone name. */
+  resolveSourceBoneName?: (targetBoneName: string) => string | null;
+}
+
 /**
  * Information about a loaded animation clip.
  */
@@ -168,6 +187,18 @@ export interface AnimationClipInfo {
   source?: AnimationSource;
   /** Derived channel metadata for partitioned baked clips. */
   channels?: BakedClipChannelInfo[];
+}
+
+/** Result returned by Loom3 after importing one or more FBX animation clips. */
+export interface FBXAnimationImportResult {
+  /** Imported clips registered with the baked animation controller. */
+  clips: unknown[];
+  /** Summary info for the registered clips. */
+  loadedClips: AnimationClipInfo[];
+  /** Number of source clips discovered in the FBX scene. */
+  sourceClipCount: number;
+  /** Number of target bones that successfully mapped to source bones. */
+  matchedBoneCount: number;
 }
 
 /**

--- a/src/engines/three/AnimationThree.fbxImport.test.ts
+++ b/src/engines/three/AnimationThree.fbxImport.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AnimationClip,
+  Bone,
+  Object3D,
+  Quaternion,
+  QuaternionKeyframeTrack,
+  Vector3,
+  VectorKeyframeTrack,
+} from 'three';
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
+import type { Profile } from '../../mappings/types';
+import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { retargetFbxAnimationClips } from './fbxAnimationImport';
+
+type TargetRig = {
+  model: Object3D;
+  hip: Bone;
+  head: Bone;
+  leftArm: Bone;
+};
+
+function makeBone(name: string, y = 0): Bone {
+  const bone = new Bone();
+  bone.name = name;
+  bone.position.set(0, y, 0);
+  return bone;
+}
+
+function makeTargetRig(): TargetRig {
+  const model = new Object3D();
+
+  const hip = makeBone('CC_Base_Hip_02', 10);
+  const waist = makeBone('CC_Base_Waist_033', 8);
+  const spine = makeBone('CC_Base_Spine01_040', 8);
+  const spine2 = makeBone('CC_Base_Spine02_041', 8);
+  const neck = makeBone('CC_Base_NeckTwist01_048', 4);
+  const head = makeBone('CC_Base_Head_049', 4);
+  const leftShoulder = makeBone('CC_Base_L_Clavicle_050', 2);
+  const leftArm = makeBone('CC_Base_L_Upperarm_051', 6);
+  const leftForearm = makeBone('CC_Base_L_Forearm_052', 6);
+  const leftHand = makeBone('CC_Base_L_Hand_053', 4);
+
+  model.add(hip);
+  hip.add(waist);
+  waist.add(spine);
+  spine.add(spine2);
+  spine2.add(neck);
+  neck.add(head);
+  spine2.add(leftShoulder);
+  leftShoulder.add(leftArm);
+  leftArm.add(leftForearm);
+  leftForearm.add(leftHand);
+  model.updateMatrixWorld(true);
+
+  return { model, hip, head, leftArm };
+}
+
+function makeSourceScene(): Object3D & { animations: AnimationClip[] } {
+  const scene = new Object3D() as Object3D & { animations: AnimationClip[] };
+
+  const hips = makeBone('mixamorig:Hips', 10);
+  const spine = makeBone('mixamorig:Spine', 8);
+  const spine1 = makeBone('mixamorig:Spine1', 8);
+  const spine2 = makeBone('mixamorig:Spine2', 8);
+  const neck = makeBone('mixamorig:Neck', 4);
+  const head = makeBone('mixamorig:Head', 4);
+  const leftShoulder = makeBone('mixamorig:LeftShoulder', 2);
+  const leftArm = makeBone('mixamorig:LeftArm', 6);
+  const leftForeArm = makeBone('mixamorig:LeftForeArm', 6);
+  const leftHand = makeBone('mixamorig:LeftHand', 4);
+
+  scene.add(hips);
+  hips.add(spine);
+  spine.add(spine1);
+  spine1.add(spine2);
+  spine2.add(neck);
+  neck.add(head);
+  spine2.add(leftShoulder);
+  leftShoulder.add(leftArm);
+  leftArm.add(leftForeArm);
+  leftForeArm.add(leftHand);
+
+  const identity = new Quaternion();
+  const raisedHead = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI / 6);
+  const raisedArm = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), -Math.PI / 4);
+
+  scene.animations = [
+    new AnimationClip('Mixamo Wave', 1, [
+      new VectorKeyframeTrack('mixamorig:Hips.position', [0, 1], [20, 12, 5, 28, 18, 9]),
+      new QuaternionKeyframeTrack(
+        'mixamorig:Head.quaternion',
+        [0, 1],
+        [identity.x, identity.y, identity.z, identity.w, raisedHead.x, raisedHead.y, raisedHead.z, raisedHead.w]
+      ),
+      new QuaternionKeyframeTrack(
+        'mixamorig:LeftArm.quaternion',
+        [0, 1],
+        [identity.x, identity.y, identity.z, identity.w, raisedArm.x, raisedArm.y, raisedArm.z, raisedArm.w]
+      ),
+      new VectorKeyframeTrack('Camera.position', [0, 1], [100, 100, 100, 120, 120, 120]),
+    ]),
+  ];
+  scene.updateMatrixWorld(true);
+
+  return scene;
+}
+
+function makeController(model: Object3D): BakedAnimationController {
+  const profile: Profile = {
+    auToMorphs: {},
+    auToBones: {},
+    boneNodes: {},
+    morphToMesh: { face: [] },
+    visemeKeys: [],
+  };
+
+  const host: BakedAnimationHost = {
+    getModel: () => model,
+    getMeshes: () => [],
+    getMeshByName: () => undefined,
+    getBones: () => ({} as any),
+    getConfig: () => profile,
+    getCompositeRotations: () => [],
+    computeSideValues: (base: number) => ({ left: base, right: base }),
+    getAUMixWeight: () => 1,
+    isMixedAU: () => false,
+  };
+
+  return new BakedAnimationController(host);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('FBX animation import', () => {
+  it('retargets Mixamo clips onto suffixed CC4 bones and strips root-position noise', async () => {
+    const { model, hip, head, leftArm } = makeTargetRig();
+    const originalHipPosition = hip.position.clone();
+    const originalHipQuaternion = hip.quaternion.clone();
+    const originalHeadQuaternion = head.quaternion.clone();
+
+    vi.spyOn(FBXLoader.prototype, 'parse').mockImplementation(() => makeSourceScene() as any);
+
+    const result = await retargetFbxAnimationClips(model, new ArrayBuffer(8));
+    expect(result.sourceClipCount).toBe(1);
+    expect(result.matchedBoneCount).toBeGreaterThanOrEqual(6);
+    expect(result.clips).toHaveLength(1);
+
+    const clip = result.clips[0]!;
+    const trackNames = clip.tracks.map((track) => track.name);
+    const headTrack = clip.tracks.find((track) => track.name === `${head.uuid}.quaternion`) as QuaternionKeyframeTrack | undefined;
+    const armTrack = clip.tracks.find((track) => track.name === `${leftArm.uuid}.quaternion`) as QuaternionKeyframeTrack | undefined;
+
+    expect(clip.name).toBe('Mixamo Wave');
+    expect(trackNames).toContain(`${head.uuid}.quaternion`);
+    expect(trackNames).toContain(`${leftArm.uuid}.quaternion`);
+    expect(trackNames.some((name) => name.includes('Camera'))).toBe(false);
+    expect(trackNames.some((name) => name.includes('.bones['))).toBe(false);
+    expect(trackNames.some((name) => name.startsWith(`${hip.uuid}.position`))).toBe(false);
+    expect(Array.from(headTrack?.values.slice(0, 4) ?? [])).not.toEqual(Array.from(headTrack?.values.slice(4, 8) ?? []));
+    expect(Array.from(armTrack?.values.slice(0, 4) ?? [])).not.toEqual(Array.from(armTrack?.values.slice(4, 8) ?? []));
+
+    expect(hip.position.toArray()).toEqual(originalHipPosition.toArray());
+    expect(hip.quaternion.toArray()).toEqual(originalHipQuaternion.toArray());
+    expect(head.quaternion.toArray()).toEqual(originalHeadQuaternion.toArray());
+  });
+
+  it('appends imported FBX clips by default and can replace the baked registry on request', async () => {
+    const { model } = makeTargetRig();
+    const controller = makeController(model);
+
+    controller.loadAnimationClips([
+      new AnimationClip('Idle', 1, []),
+    ]);
+
+    vi.spyOn(FBXLoader.prototype, 'parse').mockImplementation(() => makeSourceScene() as any);
+
+    const appended = await controller.loadAnimationClipsFromFBX(new ArrayBuffer(8));
+    expect(appended.loadedClips.map((clip) => clip.name)).toEqual(['Mixamo Wave']);
+    expect(controller.getAnimationClips().map((clip) => clip.name)).toEqual(['Idle', 'Mixamo Wave']);
+
+    const replaced = await controller.loadAnimationClipsFromFBX(new ArrayBuffer(8), {
+      append: false,
+      clipName: 'Imported Wave',
+    });
+    expect(replaced.loadedClips.map((clip) => clip.name)).toEqual(['Imported Wave']);
+    expect(controller.getAnimationClips().map((clip) => clip.name)).toEqual(['Imported Wave']);
+  });
+});

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -23,6 +23,9 @@ import type {
   TransitionHandle,
   AnimationPlayOptions,
   AnimationClipInfo,
+  FBXAnimationImportOptions,
+  FBXAnimationImportResult,
+  FBXAnimationInput,
   AnimationState,
   AnimationActionHandle,
   CurvesMap,
@@ -48,6 +51,7 @@ import {
   resolveBakedChannelBlendMode,
   type PartitionedBakedClip,
 } from './bakedClipPartitioning';
+import { retargetFbxAnimationClips } from './fbxAnimationImport';
 
 type Transition = {
   key: string;
@@ -570,46 +574,34 @@ export class BakedAnimationController {
     this.playbackState.clear();
   }
 
-  loadAnimationClips(clips: unknown[]): void {
+  private buildClipInfo(clip: AnimationClip): AnimationClipInfo {
+    return {
+      name: clip.name,
+      duration: clip.duration,
+      trackCount: clip.tracks.length,
+      source: this.clipSources.get(clip.name) ?? 'baked',
+      channels: this.getBakedSourceClip(clip.name)?.channels,
+    };
+  }
+
+  private appendAnimationClips(clips: AnimationClip[]): AnimationClipInfo[] {
     const model = this.host.getModel();
     if (!model) {
       console.warn('Loom3: Cannot load animation clips before calling onReady()');
-      return;
+      return [];
     }
-
-    for (const clipName of this.bakedSourceClips.keys()) {
-      this.stopAnimation(clipName);
-    }
-    if (this.animationMixer) {
-      for (const bakedClip of this.bakedSourceClips.values()) {
-        for (const runtimeClip of bakedClip.runtimeClips) {
-          try {
-            this.animationMixer.uncacheAction(runtimeClip.clip);
-          } catch {}
-          try {
-            this.animationMixer.uncacheClip(runtimeClip.clip);
-          } catch {}
-        }
-      }
-    }
-
-    for (const clipName of this.bakedSourceClips.keys()) {
-      this.playbackState.delete(clipName);
-      this.clipSources.delete(clipName);
-    }
-
-    this.bakedSourceClips.clear();
-    this.bakedRuntimeActions.clear();
-    this.bakedActionGroups.clear();
-    this.bakedRuntimeClipToSource.clear();
 
     this.ensureMixer();
-    const partitionedClips = (clips as AnimationClip[]).map((clip) => (
+    const partitionedClips = clips.map((clip) => (
       partitionBakedClip(clip, model, this.host.getBones())
     ));
 
-    this.animationClips = partitionedClips.map((clip) => clip.sourceClip);
+    for (const clip of clips) {
+      this.removeAnimationClip(clip.name);
+    }
+
     for (const bakedClip of partitionedClips) {
+      this.animationClips.push(bakedClip.sourceClip);
       this.bakedSourceClips.set(bakedClip.sourceClip.name, bakedClip);
       this.clipSources.set(bakedClip.sourceClip.name, 'baked');
       for (const runtimeClip of bakedClip.runtimeClips) {
@@ -619,16 +611,47 @@ export class BakedAnimationController {
         });
       }
     }
+
+    return partitionedClips.map((clip) => this.buildClipInfo(clip.sourceClip));
+  }
+
+  loadAnimationClips(clips: unknown[]): void {
+    for (const clip of [...this.animationClips]) {
+      this.removeAnimationClip(clip.name);
+    }
+
+    this.appendAnimationClips(clips as AnimationClip[]);
+  }
+
+  async loadAnimationClipsFromFBX(
+    source: FBXAnimationInput,
+    options: FBXAnimationImportOptions = {}
+  ): Promise<FBXAnimationImportResult> {
+    const model = this.host.getModel();
+    if (!model) {
+      throw new Error('Loom3: Cannot load FBX animation clips before calling onReady()');
+    }
+
+    const imported = await retargetFbxAnimationClips(model, source, options);
+
+    if (options.append === false) {
+      for (const clip of [...this.animationClips]) {
+        this.removeAnimationClip(clip.name);
+      }
+    }
+
+    const loadedClips = this.appendAnimationClips(imported.clips);
+
+    return {
+      clips: imported.clips,
+      loadedClips,
+      sourceClipCount: imported.sourceClipCount,
+      matchedBoneCount: imported.matchedBoneCount,
+    };
   }
 
   getAnimationClips(): AnimationClipInfo[] {
-    return this.animationClips.map(clip => ({
-      name: clip.name,
-      duration: clip.duration,
-      trackCount: clip.tracks.length,
-      source: this.clipSources.get(clip.name) ?? 'baked',
-      channels: this.getBakedSourceClip(clip.name)?.channels,
-    }));
+    return this.animationClips.map((clip) => this.buildClipInfo(clip));
   }
 
   removeAnimationClip(clipName: string): boolean {

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -25,6 +25,9 @@ import type {
   RotationsState,
   AnimationPlayOptions,
   AnimationClipInfo,
+  FBXAnimationInput,
+  FBXAnimationImportOptions,
+  FBXAnimationImportResult,
   AnimationState,
   AnimationActionHandle,
   CurvesMap,
@@ -1915,6 +1918,13 @@ export class Loom3 implements LoomLarge {
 
   loadAnimationClips(clips: unknown[]): void {
     this.bakedAnimations.loadAnimationClips(clips);
+  }
+
+  async loadAnimationClipsFromFBX(
+    source: FBXAnimationInput,
+    options: FBXAnimationImportOptions = {}
+  ): Promise<FBXAnimationImportResult> {
+    return this.bakedAnimations.loadAnimationClipsFromFBX(source, options);
   }
 
   getAnimationClips(): AnimationClipInfo[] {

--- a/src/engines/three/fbxAnimationImport.ts
+++ b/src/engines/three/fbxAnimationImport.ts
@@ -1,0 +1,466 @@
+import {
+  AnimationClip,
+  Bone,
+  Object3D,
+  Skeleton,
+  Vector3,
+} from 'three';
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
+import { clone, retargetClip } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import type { FBXAnimationImportOptions, FBXAnimationInput } from '../../core/types';
+
+const FBX_LOADER = new FBXLoader();
+const MIXAMO_PREFIX_PATTERN = /^mixamorig[:_]?/i;
+const CC4_PREFIX_PATTERN = /^CC_Base_/i;
+const TRAILING_EXPORT_SUFFIX_PATTERN = /(?:[_\.]\d+)+$/;
+
+const CC4_TO_MIXAMO_BONE_CANDIDATES = new Map<string, string[]>([
+  ['hip', ['Hips']],
+  ['waist', ['Spine']],
+  ['spine01', ['Spine1']],
+  ['spine02', ['Spine2']],
+  ['necktwist01', ['Neck']],
+  ['head', ['Head']],
+  ['jawroot', ['Jaw']],
+  ['leye', ['LeftEye']],
+  ['reye', ['RightEye']],
+  ['lclavicle', ['LeftShoulder']],
+  ['rclavicle', ['RightShoulder']],
+  ['lupperarm', ['LeftArm']],
+  ['rupperarm', ['RightArm']],
+  ['lforearm', ['LeftForeArm']],
+  ['rforearm', ['RightForeArm']],
+  ['lhand', ['LeftHand']],
+  ['rhand', ['RightHand']],
+  ['lthigh', ['LeftUpLeg']],
+  ['rthigh', ['RightUpLeg']],
+  ['lcalf', ['LeftLeg']],
+  ['rcalf', ['RightLeg']],
+  ['lfoot', ['LeftFoot']],
+  ['rfoot', ['RightFoot']],
+  ['ltoebase', ['LeftToeBase']],
+  ['rtoebase', ['RightToeBase']],
+]);
+
+const CC4_DIGIT_TO_MIXAMO_DIGIT: Record<string, string> = {
+  thumb: 'Thumb',
+  index: 'Index',
+  middle: 'Middle',
+  mid: 'Middle',
+  ring: 'Ring',
+  pinky: 'Pinky',
+};
+
+type SkeletonBinding = {
+  root: Object3D & { skeleton: Skeleton };
+  bones: Bone[];
+  bonesByName: Map<string, Bone | null>;
+};
+
+export type RetargetedFbxClipsResult = {
+  clips: AnimationClip[];
+  matchedBoneCount: number;
+  sourceClipCount: number;
+};
+
+function canonicalizeBoneName(name: string): string {
+  return name
+    .trim()
+    .replace(/^.*:/, '')
+    .replace(MIXAMO_PREFIX_PATTERN, '')
+    .replace(CC4_PREFIX_PATTERN, '')
+    .replace(TRAILING_EXPORT_SUFFIX_PATTERN, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function stripCc4Decorators(name: string): string {
+  return name
+    .trim()
+    .replace(/^.*:/, '')
+    .replace(TRAILING_EXPORT_SUFFIX_PATTERN, '')
+    .replace(CC4_PREFIX_PATTERN, '');
+}
+
+function buildUniqueCanonicalIndex(names: Iterable<string>): Map<string, string | null> {
+  const index = new Map<string, string | null>();
+
+  for (const name of names) {
+    const key = canonicalizeBoneName(name);
+    if (!key) continue;
+
+    const existing = index.get(key);
+    if (existing === undefined) {
+      index.set(key, name);
+      continue;
+    }
+
+    if (existing !== name) {
+      index.set(key, null);
+    }
+  }
+
+  return index;
+}
+
+function buildUniqueBoneIndex(root: Object3D): Map<string, Bone | null> {
+  const index = new Map<string, Bone | null>();
+
+  root.traverse((obj) => {
+    if (!(obj instanceof Bone) || !obj.name) return;
+
+    const existing = index.get(obj.name);
+    if (existing === undefined) {
+      index.set(obj.name, obj);
+      return;
+    }
+
+    if (existing !== obj) {
+      index.set(obj.name, null);
+    }
+  });
+
+  return index;
+}
+
+function collectBones(root: Object3D): Bone[] {
+  const bones: Bone[] = [];
+  root.traverse((obj) => {
+    if (obj instanceof Bone) {
+      bones.push(obj);
+    }
+  });
+  return bones;
+}
+
+function findTopmostBone(bones: Bone[]): Bone | null {
+  let fallback: Bone | null = bones[0] ?? null;
+
+  for (const bone of bones) {
+    let current: Object3D | null = bone.parent;
+    let hasBoneAncestor = false;
+    while (current) {
+      if (current instanceof Bone) {
+        hasBoneAncestor = true;
+        break;
+      }
+      current = current.parent;
+    }
+
+    if (!hasBoneAncestor) {
+      return bone;
+    }
+
+    fallback ??= bone;
+  }
+
+  return fallback;
+}
+
+function createSkeletonBinding(root: Object3D): SkeletonBinding {
+  let skeletonFromSkin: Skeleton | null = null;
+
+  root.traverse((obj: any) => {
+    if (skeletonFromSkin || !obj?.isSkinnedMesh || !obj.skeleton?.bones?.length) return;
+    skeletonFromSkin = obj.skeleton;
+  });
+
+  const existingSkeleton = skeletonFromSkin;
+  if (existingSkeleton) {
+    const boundRoot = root as Object3D & { skeleton: Skeleton };
+    const resolvedSkeleton = existingSkeleton as Skeleton;
+    boundRoot.skeleton = resolvedSkeleton;
+    return {
+      root: boundRoot,
+      bones: resolvedSkeleton.bones.slice(),
+      bonesByName: buildUniqueBoneIndex(root),
+    };
+  }
+
+  const bones = collectBones(root);
+  if (!bones.length) {
+    throw new Error('FBX import requires a skeleton with at least one bone');
+  }
+
+  const rootBone = findTopmostBone(bones);
+  if (!rootBone) {
+    throw new Error('FBX import could not determine the skeleton root bone');
+  }
+
+  const boundRoot = root as Object3D & { skeleton: Skeleton };
+  boundRoot.skeleton = new Skeleton(bones);
+
+  return {
+    root: boundRoot,
+    bones,
+    bonesByName: buildUniqueBoneIndex(root),
+  };
+}
+
+function resolveSourceBoneNameCandidate(
+  sourceBonesByCanonical: Map<string, string | null>,
+  candidate: string | null | undefined
+): string | null {
+  if (!candidate) return null;
+  const key = canonicalizeBoneName(candidate);
+  const resolved = sourceBonesByCanonical.get(key);
+  return typeof resolved === 'string' ? resolved : null;
+}
+
+function getDefaultSourceBoneCandidates(targetBoneName: string): string[] {
+  const candidates = new Set<string>();
+  const stripped = stripCc4Decorators(targetBoneName);
+  const directCandidate = stripped || targetBoneName;
+  const canonicalTarget = canonicalizeBoneName(directCandidate);
+
+  if (directCandidate) {
+    candidates.add(directCandidate);
+  }
+
+  const mapped = CC4_TO_MIXAMO_BONE_CANDIDATES.get(canonicalTarget);
+  mapped?.forEach((candidate) => candidates.add(candidate));
+
+  const fingerMatch = stripped.match(/^(L|R)_(Thumb|Index|Middle|Mid|Ring|Pinky)(\d+)$/i);
+  if (fingerMatch) {
+    const [, side, digit, segment] = fingerMatch;
+    const mixamoDigit = CC4_DIGIT_TO_MIXAMO_DIGIT[digit.toLowerCase()];
+    const mixamoSide = side.toUpperCase() === 'L' ? 'Left' : 'Right';
+    if (mixamoDigit) {
+      candidates.add(`${mixamoSide}Hand${mixamoDigit}${segment}`);
+    }
+  }
+
+  return Array.from(candidates);
+}
+
+function buildSourceBoneNameResolver(
+  sourceBonesByCanonical: Map<string, string | null>,
+  options: FBXAnimationImportOptions | undefined
+): (targetBoneName: string) => string | null {
+  return (targetBoneName: string) => {
+    const customResolved = resolveSourceBoneNameCandidate(
+      sourceBonesByCanonical,
+      options?.resolveSourceBoneName?.(targetBoneName) ?? null
+    );
+    if (customResolved) {
+      return customResolved;
+    }
+
+    for (const candidate of getDefaultSourceBoneCandidates(targetBoneName)) {
+      const resolved = resolveSourceBoneNameCandidate(sourceBonesByCanonical, candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return null;
+  };
+}
+
+function normalizeClipName(clip: AnimationClip, options: FBXAnimationImportOptions | undefined, index: number, total: number): string {
+  const baseName = options?.clipName?.trim() || clip.name.trim() || 'Imported Animation';
+  if (total <= 1) {
+    return baseName;
+  }
+  return `${baseName} ${index + 1}`;
+}
+
+function splitTrackName(trackName: string): { targetName: string; propertyPath: string } {
+  const dotIndex = trackName.indexOf('.');
+  if (dotIndex < 0) {
+    return { targetName: trackName, propertyPath: '' };
+  }
+
+  return {
+    targetName: trackName.slice(0, dotIndex),
+    propertyPath: trackName.slice(dotIndex),
+  };
+}
+
+function makeSafeBindingName(name: string, usedNames: Set<string>): string {
+  const baseName = name
+    .trim()
+    .replace(/[^A-Za-z0-9_]/g, '_')
+    .replace(/^_+|_+$/g, '') || 'Bone';
+
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseName}_${suffix}`;
+  while (usedNames.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseName}_${suffix}`;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
+}
+
+function normalizeSourceSceneForRetarget(sourceScene: Object3D & { animations?: AnimationClip[] }): void {
+  const usedBoneNames = new Set<string>();
+  const renamedBones = new Map<string, string>();
+
+  sourceScene.traverse((obj) => {
+    if (!(obj instanceof Bone) || !obj.name) return;
+    const safeName = makeSafeBindingName(obj.name, usedBoneNames);
+    renamedBones.set(obj.name, safeName);
+    obj.name = safeName;
+  });
+
+  sourceScene.animations = (sourceScene.animations ?? []).map((clip) => {
+    const renamedTracks = clip.tracks.flatMap((track) => {
+      const { targetName, propertyPath } = splitTrackName(track.name);
+      const safeTargetName = renamedBones.get(targetName);
+      if (!safeTargetName || !propertyPath) {
+        return [];
+      }
+
+      const clonedTrack = track.clone();
+      clonedTrack.name = `${safeTargetName}${propertyPath}`;
+      return [clonedTrack];
+    });
+
+    return new AnimationClip(clip.name, clip.duration, renamedTracks);
+  });
+}
+
+function sliceArrayBuffer(view: ArrayBufferView): ArrayBuffer {
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+}
+
+async function readInputBuffer(source: FBXAnimationInput): Promise<ArrayBuffer> {
+  if (source instanceof ArrayBuffer) {
+    return source.slice(0);
+  }
+
+  if (ArrayBuffer.isView(source)) {
+    return sliceArrayBuffer(source);
+  }
+
+  if (source instanceof Blob) {
+    return source.arrayBuffer();
+  }
+
+  throw new Error('Unsupported FBX animation input type');
+}
+
+function findHipBoneMapping(
+  targetBones: Bone[],
+  resolveSourceBoneName: (targetBoneName: string) => string | null
+): { targetBoneName: string | null; sourceBoneName: string | null } {
+  for (const bone of targetBones) {
+    const sourceBoneName = resolveSourceBoneName(bone.name);
+    if (!sourceBoneName) continue;
+
+    if (canonicalizeBoneName(bone.name) === 'hip' || canonicalizeBoneName(sourceBoneName) === 'hips') {
+      return {
+        targetBoneName: bone.name,
+        sourceBoneName,
+      };
+    }
+  }
+
+  return {
+    targetBoneName: null,
+    sourceBoneName: null,
+  };
+}
+
+function renameTrackToTargetBoneUuid(
+  trackName: string,
+  targetBonesByName: Map<string, Bone | null>
+): { boneName: string; renamedTrackName: string } | null {
+  const match = trackName.match(/^\.bones\[(.+?)\](\..+)$/);
+  if (!match) return null;
+
+  const [, boneName, propertyPath] = match;
+  const targetBone = targetBonesByName.get(boneName);
+  if (!targetBone) return null;
+
+  return {
+    boneName,
+    renamedTrackName: `${targetBone.uuid}${propertyPath}`,
+  };
+}
+
+function normalizeRetargetedClip(
+  clip: AnimationClip,
+  targetBonesByName: Map<string, Bone | null>,
+  hipBoneName: string | null,
+  inPlace: boolean
+): AnimationClip {
+  const normalizedTracks = clip.tracks.flatMap((track) => {
+    const renamed = renameTrackToTargetBoneUuid(track.name, targetBonesByName);
+    if (!renamed) return [];
+
+    if (inPlace && hipBoneName && renamed.boneName === hipBoneName && renamed.renamedTrackName.endsWith('.position')) {
+      return [];
+    }
+
+    const clonedTrack = track.clone();
+    clonedTrack.name = renamed.renamedTrackName;
+    return [clonedTrack];
+  });
+
+  const normalizedClip = new AnimationClip(clip.name, clip.duration, normalizedTracks);
+  normalizedClip.resetDuration();
+  return normalizedClip;
+}
+
+export async function retargetFbxAnimationClips(
+  model: Object3D,
+  source: FBXAnimationInput,
+  options: FBXAnimationImportOptions = {}
+): Promise<RetargetedFbxClipsResult> {
+  const modelClone = clone(model);
+  const sourceBuffer = await readInputBuffer(source);
+  const sourceScene = FBX_LOADER.parse(sourceBuffer, '');
+  normalizeSourceSceneForRetarget(sourceScene as Object3D & { animations?: AnimationClip[] });
+
+  if (!sourceScene.animations?.length) {
+    throw new Error('FBX import did not find any animation clips');
+  }
+
+  modelClone.updateMatrixWorld(true);
+  sourceScene.updateMatrixWorld(true);
+
+  const targetBinding = createSkeletonBinding(modelClone);
+  const sourceBinding = createSkeletonBinding(sourceScene);
+  const sourceBonesByCanonical = buildUniqueCanonicalIndex(sourceBinding.bones.map((bone) => bone.name));
+  const resolveSourceBoneName = buildSourceBoneNameResolver(sourceBonesByCanonical, options);
+  const matchedBoneCount = targetBinding.bones.reduce((count, bone) => {
+    return resolveSourceBoneName(bone.name) ? count + 1 : count;
+  }, 0);
+
+  if (matchedBoneCount === 0) {
+    throw new Error('FBX import could not match any source bones to the current rig');
+  }
+
+  const actualTargetBonesByName = buildUniqueBoneIndex(model);
+  const hipBone = findHipBoneMapping(targetBinding.bones, resolveSourceBoneName);
+  const importedClips = sourceScene.animations.map((sourceClip, index, clips) => {
+    const retargeted = retargetClip(targetBinding.root, sourceBinding.root, sourceClip, {
+      fps: options.fps,
+      useFirstFramePosition: options.useFirstFramePosition ?? false,
+      hip: hipBone.sourceBoneName ?? 'Hips',
+      hipInfluence: options.inPlace === false ? new Vector3(1, 1, 1) : new Vector3(0, 0, 0),
+      hipPosition: options.inPlace === false ? undefined : new Vector3(),
+      getBoneName: (bone: Bone) => resolveSourceBoneName(bone.name) ?? bone.name,
+    });
+    retargeted.name = normalizeClipName(sourceClip, options, index, clips.length);
+    return normalizeRetargetedClip(retargeted, actualTargetBonesByName, hipBone.targetBoneName, options.inPlace !== false);
+  }).filter((clip) => clip.tracks.length > 0);
+
+  if (!importedClips.length) {
+    throw new Error('FBX import produced no compatible animation tracks for the current rig');
+  }
+
+  return {
+    clips: importedClips,
+    matchedBoneCount,
+    sourceClipCount: sourceScene.animations.length,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,9 @@ export type {
   AnimationEasing,
   AnimationPlayOptions,
   AnimationClipInfo,
+  FBXAnimationInput,
+  FBXAnimationImportOptions,
+  FBXAnimationImportResult,
   AnimationState,
   AnimationActionHandle,
   // Snippet-to-clip types

--- a/src/interfaces/Animation.ts
+++ b/src/interfaces/Animation.ts
@@ -8,6 +8,9 @@ import type {
   TransitionHandle,
   AnimationPlayOptions,
   AnimationClipInfo,
+  FBXAnimationImportOptions,
+  FBXAnimationImportResult,
+  FBXAnimationInput,
   AnimationState,
   AnimationActionHandle,
   ClipOptions,
@@ -189,6 +192,13 @@ export interface Animation {
    * @param clips - Array of AnimationClip objects from GLTF loader
    */
   loadAnimationClips(clips: unknown[]): void;
+
+  /**
+   * Parse, retarget, and register baked animation clips from an FBX file.
+   * The imported clips are sanitized to the current rig before they are added
+   * to the baked animation registry.
+   */
+  loadAnimationClipsFromFBX(source: FBXAnimationInput, options?: FBXAnimationImportOptions): Promise<FBXAnimationImportResult>;
 
   /**
    * Get list of all loaded animation clips.


### PR DESCRIPTION
## Summary
Adds a dedicated Loom3-side FBX animation import path that parses an FBX clip, retargets it onto the current rig, strips unsafe non-bone/root-motion behavior by default, and registers the result as baked clips.

## Why
LoomLarge PR #413 exposed the real issue with Mixamo-on-CC4 playback: the current pipeline only rebinding track names is not enough. Mixamo FBX clips carry source-rig bone-space rotations plus extra scene/root tracks, so playing them directly on a CC rig produces wrong pose/facing/root behavior.

Moving the import step into Loom3 gives us a stable place to:
- parse FBX directly
- retarget source bone transforms onto the loaded target rig
- ignore non-bone tracks like cameras
- keep imported clips in place by default instead of dragging the character around
- register the result through the existing baked animation mixer path

## What changed
- added `loadAnimationClipsFromFBX(...)` to the public animation/Loom3 API
- added a new `fbxAnimationImport` helper that:
  - normalizes source FBX bone names for reliable Three.js binding
  - maps Mixamo bones onto CC4/Character Creator target rigs, including suffixed export variants
  - retargets via `SkeletonUtils.retargetClip(...)`
  - rewrites the retargeted tracks into Loom3's existing UUID-based baked clip format
  - drops root position tracks by default so imported clips play in place
- updated the baked clip controller so imported clips can append to the current baked registry instead of replacing it unless explicitly requested
- added focused tests for the FBX retarget/import flow and registry behavior

## Consumer impact
This is the Loom3 runtime counterpart to LoomLarge PR #413:
- LoomLarge can switch from ad hoc FBX track rewriting to this dedicated Loom3 import API
- saved/imported Mixamo clips can still flow through the normal baked animation registry once loaded

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`

## Follow-up
- LoomLarge consumer PR: meekmachine/LoomLarge#413