### PR TITLE
[codex] Convert baked bone tracks for additive playback

### DIFF
--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   AnimationClip,
+  Bone,
   Quaternion,
   Vector3,
   Mesh,
@@ -240,7 +241,7 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationClips()[0]?.supportsAdditive).toBe(true);
   });
 
-  it('allows additive baked playback while filtering resolved head bone rotation tracks', () => {
+  it('converts resolved head bone rotation tracks to additive deltas', () => {
     const { controller, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
     head!.rotation.z = (5 * Math.PI) / 180;
@@ -252,7 +253,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('HeadNod', 1);
-    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(controller.getAnimationState('HeadNod')).toMatchObject({
       name: 'HeadNod',
       requestedBlendMode: 'additive',
@@ -265,7 +266,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('allows additive baked playback while filtering resolved bone position tracks', () => {
+  it('converts resolved bone position tracks to additive deltas', () => {
     const { controller, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
     head!.position.x = 3;
@@ -277,7 +278,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('HeadShift', 1);
-    expect(head!.position.x).toBeCloseTo(3, 3);
+    expect(head!.position.x).toBeCloseTo(4, 3);
     expect(controller.getAnimationState('HeadShift')).toMatchObject({
       name: 'HeadShift',
       requestedBlendMode: 'additive',
@@ -286,7 +287,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('allows additive baked playback while filtering hip bone rotation tracks', () => {
+  it('converts hip bone rotation tracks to additive deltas', () => {
     const { controller, hip } = makeHost({ includeHipBone: true });
     expect(hip).toBeTruthy();
     hip!.rotation.z = (5 * Math.PI) / 180;
@@ -298,7 +299,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('HipTurn', 1);
-    expect((hip!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((hip!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(controller.getAnimationState('HipTurn')).toMatchObject({
       name: 'HipTurn',
       requestedBlendMode: 'additive',
@@ -307,7 +308,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('allows additive baked playback while filtering foot bone rotation tracks', () => {
+  it('converts foot bone rotation tracks to additive deltas', () => {
     const { controller, foot } = makeHost({ includeFootBone: true });
     expect(foot).toBeTruthy();
     foot!.rotation.z = (5 * Math.PI) / 180;
@@ -319,7 +320,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('FootLift', 1);
-    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(controller.getAnimationState('FootLift')).toMatchObject({
       name: 'FootLift',
       requestedBlendMode: 'additive',
@@ -328,7 +329,30 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('keeps safe morph tracks additive while filtering jaw rotation tracks', () => {
+  it('converts unmapped Three bone tracks instead of dropping the whole baked clip', () => {
+    const { controller, model } = makeHost();
+    const leg = new Bone();
+    leg.name = 'UnmappedLeg';
+    model.add(leg);
+    leg.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeQuaternionPoseClip(leg, 'LegLift', 10, 20)]);
+
+    const handle = controller.playAnimation('LegLift', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('LegLift', 1);
+    expect((leg.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
+    expect(controller.getAnimationState('LegLift')).toMatchObject({
+      name: 'LegLift',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+  });
+
+  it('keeps morph tracks additive while converting jaw rotation tracks to additive deltas', () => {
     const { controller, mesh, jaw } = makeHost({ includeJawBone: true });
     expect(jaw).toBeTruthy();
     jaw!.rotation.z = (5 * Math.PI) / 180;
@@ -340,7 +364,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('SmileWithJaw', 1);
-    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
     expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
       name: 'SmileWithJaw',
@@ -371,7 +395,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('keeps morph tracks additive while filtering head bone rotation tracks', () => {
+  it('keeps morph tracks additive while converting head bone rotation tracks to additive deltas', () => {
     const { controller, mesh, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
     head!.rotation.z = (5 * Math.PI) / 180;
@@ -383,7 +407,7 @@ describe('BakedAnimationController playback state normalization', () => {
 
     expect(handle).toBeTruthy();
     controller.seekAnimation('SmileWithHeadTurn', 1);
-    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
     expect(controller.getAnimationState('SmileWithHeadTurn')).toMatchObject({
       name: 'SmileWithHeadTurn',
@@ -393,7 +417,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('keeps morph tracks additive while filtering foot bone rotation tracks', () => {
+  it('keeps morph tracks additive while converting foot bone rotation tracks to additive deltas', () => {
     const { controller, mesh, foot } = makeHost({ includeFootBone: true });
     expect(foot).toBeTruthy();
     foot!.rotation.z = (5 * Math.PI) / 180;
@@ -407,7 +431,7 @@ describe('BakedAnimationController playback state normalization', () => {
     controller.seekAnimation('SmileWithFootLift', 0);
     expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
     controller.seekAnimation('SmileWithFootLift', 1);
-    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
     expect(controller.getAnimationState('SmileWithFootLift')).toMatchObject({
       name: 'SmileWithFootLift',
@@ -574,7 +598,7 @@ describe('BakedAnimationController playback state normalization', () => {
       supportsAdditive: true,
     });
     expect(controller.getAnimationState('SmileWithJaw')?.actionId).not.toBe(replaceActionId);
-    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(15, 3);
     expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
   });
 

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -18,6 +18,7 @@ const Z_AXIS = new Vector3(0, 0, 1);
 function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean; includeJawBone?: boolean } = {}): {
   controller: BakedAnimationController;
   model: Object3D;
+  mesh: Mesh;
   head: Object3D | null;
   hip: Object3D | null;
   jaw: Object3D | null;
@@ -101,7 +102,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), model, head, hip, jaw };
+  return { controller: new BakedAnimationController(host), model, mesh, head, hip, jaw };
 }
 
 function makeTransformClip(model: Object3D, name: string): AnimationClip {
@@ -138,6 +139,19 @@ function makeJawQuaternionClip(target: Object3D, name: string, startDeg: number,
   const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
   const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
   return new AnimationClip(name, 1, [
+    new QuaternionKeyframeTrack(
+      `${target.uuid}.quaternion`,
+      [0, 1],
+      [start.x, start.y, start.z, start.w, end.x, end.y, end.z, end.w]
+    ),
+  ]);
+}
+
+function makeMixedMorphJawClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
+  const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
+  const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
+  return new AnimationClip(name, 1, [
+    new NumberKeyframeTrack('FaceMesh.morphTargetInfluences[0]', [0, 1], [0, 1]),
     new QuaternionKeyframeTrack(
       `${target.uuid}.quaternion`,
       [0, 1],
@@ -248,25 +262,25 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('falls back to replace for jaw rotation tracks so additive playback does not double-open the mouth', () => {
-    const { controller, jaw } = makeHost({ includeJawBone: true });
+  it('keeps safe morph tracks additive while filtering jaw rotation tracks', () => {
+    const { controller, mesh, jaw } = makeHost({ includeJawBone: true });
     expect(jaw).toBeTruthy();
     jaw!.rotation.z = (5 * Math.PI) / 180;
-    controller.loadAnimationClips([makeJawQuaternionClip(jaw!, 'JawOpen', 10, 20)]);
+    controller.loadAnimationClips([makeMixedMorphJawClip(jaw!, 'SmileWithJaw', 10, 20)]);
 
-    const handle = controller.playAnimation('JawOpen', {
+    const handle = controller.playAnimation('SmileWithJaw', {
       blendMode: 'additive',
     });
 
     expect(handle).toBeTruthy();
-    controller.seekAnimation('JawOpen', 0);
-    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(10, 3);
-    expect(controller.getAnimationState('JawOpen')).toMatchObject({
-      name: 'JawOpen',
+    controller.seekAnimation('SmileWithJaw', 1);
+    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
+    expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
+      name: 'SmileWithJaw',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
   });
 
@@ -388,15 +402,52 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('keeps unsafe baked clips on replace when additive is toggled after playback starts', () => {
-    const { controller, model } = makeHost();
-    controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
+  it('switches mixed baked clips to filtered additive playback when toggled after playback starts', () => {
+    const { controller, mesh, jaw } = makeHost({ includeJawBone: true });
+    expect(jaw).toBeTruthy();
+    jaw!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeMixedMorphJawClip(jaw!, 'SmileWithJaw', 10, 20)]);
 
-    controller.playAnimation('Idle');
-    controller.setAnimationBlendMode('Idle', 'additive');
+    controller.playAnimation('SmileWithJaw');
+    const replaceActionId = controller.getAnimationState('SmileWithJaw')?.actionId;
 
-    expect(controller.getAnimationState('Idle')).toMatchObject({
-      name: 'Idle',
+    controller.setAnimationBlendMode('SmileWithJaw', 'additive');
+    jaw!.rotation.z = (5 * Math.PI) / 180;
+    controller.seekAnimation('SmileWithJaw', 1);
+
+    expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
+      name: 'SmileWithJaw',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+    expect(controller.getAnimationState('SmileWithJaw')?.actionId).not.toBe(replaceActionId);
+    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
+  });
+
+  it('clears filtered additive caches when a baked clip is removed and reloaded', () => {
+    const { controller, model, jaw } = makeHost({ includeJawBone: true });
+    expect(jaw).toBeTruthy();
+    controller.loadAnimationClips([makeMixedMorphJawClip(jaw!, 'SmileWithJaw', 10, 20)]);
+
+    controller.playAnimation('SmileWithJaw', {
+      blendMode: 'additive',
+    });
+    expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+
+    expect(controller.removeAnimationClip('SmileWithJaw')).toBe(true);
+    controller.loadAnimationClips([makeTransformClip(model, 'SmileWithJaw')]);
+
+    const handle = controller.playAnimation('SmileWithJaw', {
+      blendMode: 'additive',
+    });
+    expect(handle).toBeTruthy();
+    expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
+      name: 'SmileWithJaw',
       requestedBlendMode: 'additive',
       blendMode: 'replace',
       supportsAdditive: false,

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   AnimationClip,
   Quaternion,
@@ -15,13 +15,20 @@ import { BakedAnimationController, type BakedAnimationHost } from './AnimationTh
 
 const Z_AXIS = new Vector3(0, 0, 1);
 
-function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean; includeJawBone?: boolean } = {}): {
+function makeHost(options: {
+  includeHeadBone?: boolean;
+  includeHipBone?: boolean;
+  includeJawBone?: boolean;
+  includeFootBone?: boolean;
+  reapplyProceduralState?: () => void;
+} = {}): {
   controller: BakedAnimationController;
   model: Object3D;
   mesh: Mesh;
   head: Object3D | null;
   hip: Object3D | null;
   jaw: Object3D | null;
+  foot: Object3D | null;
 } {
   const model = new Object3D();
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
@@ -43,6 +50,11 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
   if (jaw) {
     jaw.name = 'Jaw';
     model.add(jaw);
+  }
+  const foot = options.includeFootBone ? new Object3D() : null;
+  if (foot) {
+    foot.name = 'L_Foot';
+    model.add(foot);
   }
 
   const bones = {
@@ -76,6 +88,16 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
         },
       }
       : {}),
+    ...(foot
+      ? {
+        FOOT_L: {
+          obj: foot,
+          basePos: { x: foot.position.x, y: foot.position.y, z: foot.position.z },
+          baseQuat: foot.quaternion.clone(),
+          baseEuler: { x: foot.rotation.x, y: foot.rotation.y, z: foot.rotation.z, order: foot.rotation.order },
+        },
+      }
+      : {}),
   };
 
   const profile: Profile = {
@@ -85,6 +107,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
       ...(head ? { HEAD: 'Head' } : {}),
       ...(hip ? { HIPS: 'CC_Base_Hip' } : {}),
       ...(jaw ? { JAW: 'Jaw' } : {}),
+      ...(foot ? { FOOT_L: 'L_Foot' } : {}),
     },
     morphToMesh: { face: ['FaceMesh'] },
     visemeKeys: [],
@@ -100,9 +123,10 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
     computeSideValues: (base: number) => ({ left: base, right: base }),
     getAUMixWeight: () => 1,
     isMixedAU: () => false,
+    reapplyProceduralState: options.reapplyProceduralState,
   };
 
-  return { controller: new BakedAnimationController(host), model, mesh, head, hip, jaw };
+  return { controller: new BakedAnimationController(host), model, mesh, head, hip, jaw, foot };
 }
 
 function makeTransformClip(model: Object3D, name: string): AnimationClip {
@@ -117,9 +141,27 @@ function makeMorphClip(name: string): AnimationClip {
   ]);
 }
 
+function makeMorphPoseClip(name: string, start: number, end: number): AnimationClip {
+  return new AnimationClip(name, 1, [
+    new NumberKeyframeTrack('FaceMesh.morphTargetInfluences[0]', [0, 1], [start, end]),
+  ]);
+}
+
 function makeSafeBoneClip(head: Object3D, name: string): AnimationClip {
   return new AnimationClip(name, 1, [
     new QuaternionKeyframeTrack(`${head.uuid}.quaternion`, [0, 1], [0, 0, 0, 1, 0, 0, 0, 1]),
+  ]);
+}
+
+function makeQuaternionPoseClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
+  const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
+  const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
+  return new AnimationClip(name, 1, [
+    new QuaternionKeyframeTrack(
+      `${target.uuid}.quaternion`,
+      [0, 1],
+      [start.x, start.y, start.z, start.w, end.x, end.y, end.z, end.w]
+    ),
   ]);
 }
 
@@ -136,18 +178,14 @@ function makeBoneQuaternionClip(target: Object3D, name: string): AnimationClip {
 }
 
 function makeJawQuaternionClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
-  const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
-  const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
-  return new AnimationClip(name, 1, [
-    new QuaternionKeyframeTrack(
-      `${target.uuid}.quaternion`,
-      [0, 1],
-      [start.x, start.y, start.z, start.w, end.x, end.y, end.z, end.w]
-    ),
-  ]);
+  return makeQuaternionPoseClip(target, name, startDeg, endDeg);
 }
 
 function makeMixedMorphJawClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
+  return makeMixedMorphQuaternionClip(target, name, startDeg, endDeg);
+}
+
+function makeMixedMorphQuaternionClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
   const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
   const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
   return new AnimationClip(name, 1, [
@@ -202,7 +240,7 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationClips()[0]?.supportsAdditive).toBe(true);
   });
 
-  it('allows additive baked playback for resolved facial/head transform tracks', () => {
+  it('falls back to replace for resolved head bone rotation tracks', () => {
     const { controller, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
     controller.loadAnimationClips([makeSafeBoneClip(head!, 'HeadNod')]);
@@ -215,12 +253,14 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationState('HeadNod')).toMatchObject({
       name: 'HeadNod',
       requestedBlendMode: 'additive',
-      blendMode: 'additive',
-      supportsAdditive: true,
+      blendMode: 'replace',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
     });
     expect(controller.getAnimationClips()[0]).toMatchObject({
       name: 'HeadNod',
-      supportsAdditive: true,
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
     });
   });
 
@@ -262,6 +302,25 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
+  it('falls back to replace for resolved foot bone rotation tracks', () => {
+    const { controller, foot } = makeHost({ includeFootBone: true });
+    expect(foot).toBeTruthy();
+    controller.loadAnimationClips([makeBoneQuaternionClip(foot!, 'FootLift')]);
+
+    const handle = controller.playAnimation('FootLift', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    expect(controller.getAnimationState('FootLift')).toMatchObject({
+      name: 'FootLift',
+      requestedBlendMode: 'additive',
+      blendMode: 'replace',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
+    });
+  });
+
   it('keeps safe morph tracks additive while filtering jaw rotation tracks', () => {
     const { controller, mesh, jaw } = makeHost({ includeJawBone: true });
     expect(jaw).toBeTruthy();
@@ -282,6 +341,91 @@ describe('BakedAnimationController playback state normalization', () => {
       blendMode: 'additive',
       supportsAdditive: true,
     });
+  });
+
+  it('applies additive morph tracks relative to the neutral mesh state instead of the clip start pose', () => {
+    const { controller, mesh } = makeHost();
+    controller.loadAnimationClips([makeMorphPoseClip('SmilePose', 0.4, 1)]);
+
+    const handle = controller.playAnimation('SmilePose', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('SmilePose', 0);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.4, 3);
+    controller.seekAnimation('SmilePose', 1);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
+    expect(controller.getAnimationState('SmilePose')).toMatchObject({
+      name: 'SmilePose',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+  });
+
+  it('keeps morph tracks additive while filtering head bone rotation tracks', () => {
+    const { controller, mesh, head } = makeHost({ includeHeadBone: true });
+    expect(head).toBeTruthy();
+    head!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeMixedMorphQuaternionClip(head!, 'SmileWithHeadTurn', 10, 20)]);
+
+    const handle = controller.playAnimation('SmileWithHeadTurn', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('SmileWithHeadTurn', 1);
+    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
+    expect(controller.getAnimationState('SmileWithHeadTurn')).toMatchObject({
+      name: 'SmileWithHeadTurn',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+  });
+
+  it('keeps morph tracks additive while filtering foot bone rotation tracks', () => {
+    const { controller, mesh, foot } = makeHost({ includeFootBone: true });
+    expect(foot).toBeTruthy();
+    foot!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeMixedMorphQuaternionClip(foot!, 'SmileWithFootLift', 10, 20)]);
+
+    const handle = controller.playAnimation('SmileWithFootLift', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('SmileWithFootLift', 0);
+    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    controller.seekAnimation('SmileWithFootLift', 1);
+    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(1, 3);
+    expect(controller.getAnimationState('SmileWithFootLift')).toMatchObject({
+      name: 'SmileWithFootLift',
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      supportsAdditive: true,
+    });
+  });
+
+  it('reapplies procedural state after additive baked mixer updates', () => {
+    const reapplyProceduralState = vi.fn();
+    const { controller } = makeHost({ reapplyProceduralState });
+    controller.loadAnimationClips([makeMorphClip('Smile')]);
+
+    controller.playAnimation('Smile', { blendMode: 'additive' });
+    controller.update(1 / 60);
+
+    expect(reapplyProceduralState).toHaveBeenCalledTimes(1);
+
+    reapplyProceduralState.mockClear();
+    controller.stopAnimation('Smile');
+    controller.playAnimation('Smile', { blendMode: 'replace' });
+    controller.update(1 / 60);
+
+    expect(reapplyProceduralState).not.toHaveBeenCalled();
   });
 
   it('applies the same normalized aliases to clip-backed playback', () => {

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   AnimationClip,
+  Quaternion,
+  Vector3,
   Mesh,
   MeshBasicMaterial,
   NumberKeyframeTrack,
@@ -11,11 +13,14 @@ import {
 import type { Profile } from '../../mappings/types';
 import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
 
-function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean } = {}): {
+const Z_AXIS = new Vector3(0, 0, 1);
+
+function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean; includeJawBone?: boolean } = {}): {
   controller: BakedAnimationController;
   model: Object3D;
   head: Object3D | null;
   hip: Object3D | null;
+  jaw: Object3D | null;
 } {
   const model = new Object3D();
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
@@ -32,6 +37,11 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
   if (hip) {
     hip.name = 'CC_Base_Hip';
     model.add(hip);
+  }
+  const jaw = options.includeJawBone ? new Object3D() : null;
+  if (jaw) {
+    jaw.name = 'Jaw';
+    model.add(jaw);
   }
 
   const bones = {
@@ -55,6 +65,16 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
         },
       }
       : {}),
+    ...(jaw
+      ? {
+        JAW: {
+          obj: jaw,
+          basePos: { x: jaw.position.x, y: jaw.position.y, z: jaw.position.z },
+          baseQuat: jaw.quaternion.clone(),
+          baseEuler: { x: jaw.rotation.x, y: jaw.rotation.y, z: jaw.rotation.z, order: jaw.rotation.order },
+        },
+      }
+      : {}),
   };
 
   const profile: Profile = {
@@ -63,6 +83,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
     boneNodes: {
       ...(head ? { HEAD: 'Head' } : {}),
       ...(hip ? { HIPS: 'CC_Base_Hip' } : {}),
+      ...(jaw ? { JAW: 'Jaw' } : {}),
     },
     morphToMesh: { face: ['FaceMesh'] },
     visemeKeys: [],
@@ -80,7 +101,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeHipBone?: boolean
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), model, head, hip };
+  return { controller: new BakedAnimationController(host), model, head, hip, jaw };
 }
 
 function makeTransformClip(model: Object3D, name: string): AnimationClip {
@@ -110,6 +131,18 @@ function makeBonePositionClip(target: Object3D, name: string): AnimationClip {
 function makeBoneQuaternionClip(target: Object3D, name: string): AnimationClip {
   return new AnimationClip(name, 1, [
     new QuaternionKeyframeTrack(`${target.uuid}.quaternion`, [0, 1], [0, 0, 0, 1, 0, 0, 0, 1]),
+  ]);
+}
+
+function makeJawQuaternionClip(target: Object3D, name: string, startDeg: number, endDeg: number): AnimationClip {
+  const start = new Quaternion().setFromAxisAngle(Z_AXIS, (startDeg * Math.PI) / 180);
+  const end = new Quaternion().setFromAxisAngle(Z_AXIS, (endDeg * Math.PI) / 180);
+  return new AnimationClip(name, 1, [
+    new QuaternionKeyframeTrack(
+      `${target.uuid}.quaternion`,
+      [0, 1],
+      [start.x, start.y, start.z, start.w, end.x, end.y, end.z, end.w]
+    ),
   ]);
 }
 
@@ -208,6 +241,28 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(handle).toBeTruthy();
     expect(controller.getAnimationState('HipTurn')).toMatchObject({
       name: 'HipTurn',
+      requestedBlendMode: 'additive',
+      blendMode: 'replace',
+      supportsAdditive: false,
+      additiveModeReason: 'unsafe_baked_additive_tracks',
+    });
+  });
+
+  it('falls back to replace for jaw rotation tracks so additive playback does not double-open the mouth', () => {
+    const { controller, jaw } = makeHost({ includeJawBone: true });
+    expect(jaw).toBeTruthy();
+    jaw!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeJawQuaternionClip(jaw!, 'JawOpen', 10, 20)]);
+
+    const handle = controller.playAnimation('JawOpen', {
+      blendMode: 'additive',
+    });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('JawOpen', 0);
+    expect((jaw!.rotation.z * 180) / Math.PI).toBeCloseTo(10, 3);
+    expect(controller.getAnimationState('JawOpen')).toMatchObject({
+      name: 'JawOpen',
       requestedBlendMode: 'additive',
       blendMode: 'replace',
       supportsAdditive: false,

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -240,33 +240,35 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationClips()[0]?.supportsAdditive).toBe(true);
   });
 
-  it('falls back to replace for resolved head bone rotation tracks', () => {
+  it('allows additive baked playback while filtering resolved head bone rotation tracks', () => {
     const { controller, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
-    controller.loadAnimationClips([makeSafeBoneClip(head!, 'HeadNod')]);
+    head!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeQuaternionPoseClip(head!, 'HeadNod', 10, 20)]);
 
     const handle = controller.playAnimation('HeadNod', {
       blendMode: 'additive',
     });
 
     expect(handle).toBeTruthy();
+    controller.seekAnimation('HeadNod', 1);
+    expect((head!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
     expect(controller.getAnimationState('HeadNod')).toMatchObject({
       name: 'HeadNod',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
     expect(controller.getAnimationClips()[0]).toMatchObject({
       name: 'HeadNod',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      supportsAdditive: true,
     });
   });
 
-  it('falls back to replace for resolved bone position tracks even when the bone is whitelisted', () => {
+  it('allows additive baked playback while filtering resolved bone position tracks', () => {
     const { controller, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
+    head!.position.x = 3;
     controller.loadAnimationClips([makeBonePositionClip(head!, 'HeadShift')]);
 
     const handle = controller.playAnimation('HeadShift', {
@@ -274,50 +276,55 @@ describe('BakedAnimationController playback state normalization', () => {
     });
 
     expect(handle).toBeTruthy();
+    controller.seekAnimation('HeadShift', 1);
+    expect(head!.position.x).toBeCloseTo(3, 3);
     expect(controller.getAnimationState('HeadShift')).toMatchObject({
       name: 'HeadShift',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
   });
 
-  it('falls back to replace for root-like bone rotation tracks even when they resolve as bones', () => {
+  it('allows additive baked playback while filtering hip bone rotation tracks', () => {
     const { controller, hip } = makeHost({ includeHipBone: true });
     expect(hip).toBeTruthy();
-    controller.loadAnimationClips([makeBoneQuaternionClip(hip!, 'HipTurn')]);
+    hip!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeQuaternionPoseClip(hip!, 'HipTurn', 10, 20)]);
 
     const handle = controller.playAnimation('HipTurn', {
       blendMode: 'additive',
     });
 
     expect(handle).toBeTruthy();
+    controller.seekAnimation('HipTurn', 1);
+    expect((hip!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
     expect(controller.getAnimationState('HipTurn')).toMatchObject({
       name: 'HipTurn',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
   });
 
-  it('falls back to replace for resolved foot bone rotation tracks', () => {
+  it('allows additive baked playback while filtering foot bone rotation tracks', () => {
     const { controller, foot } = makeHost({ includeFootBone: true });
     expect(foot).toBeTruthy();
-    controller.loadAnimationClips([makeBoneQuaternionClip(foot!, 'FootLift')]);
+    foot!.rotation.z = (5 * Math.PI) / 180;
+    controller.loadAnimationClips([makeQuaternionPoseClip(foot!, 'FootLift', 10, 20)]);
 
     const handle = controller.playAnimation('FootLift', {
       blendMode: 'additive',
     });
 
     expect(handle).toBeTruthy();
+    controller.seekAnimation('FootLift', 1);
+    expect((foot!.rotation.z * 180) / Math.PI).toBeCloseTo(5, 3);
     expect(controller.getAnimationState('FootLift')).toMatchObject({
       name: 'FootLift',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
   });
 
@@ -523,8 +530,9 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationState('Wave')?.time).toBeCloseTo(1, 5);
   });
 
-  it('falls back to replace when additive is requested for baked transform clips', () => {
+  it('allows additive no-op playback when every baked track is filtered', () => {
     const { controller, model } = makeHost();
+    model.position.x = 3;
     controller.loadAnimationClips([makeTransformClip(model, 'Idle')]);
 
     const handle = controller.playAnimation('Idle', {
@@ -532,17 +540,17 @@ describe('BakedAnimationController playback state normalization', () => {
     });
 
     expect(handle).toBeTruthy();
+    controller.seekAnimation('Idle', 1);
+    expect(model.position.x).toBeCloseTo(3, 3);
     expect(controller.getAnimationState('Idle')).toMatchObject({
       name: 'Idle',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
     expect(controller.getAnimationClips()[0]).toMatchObject({
       name: 'Idle',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      supportsAdditive: true,
     });
   });
 
@@ -593,9 +601,8 @@ describe('BakedAnimationController playback state normalization', () => {
     expect(controller.getAnimationState('SmileWithJaw')).toMatchObject({
       name: 'SmileWithJaw',
       requestedBlendMode: 'additive',
-      blendMode: 'replace',
-      supportsAdditive: false,
-      additiveModeReason: 'unsafe_baked_additive_tracks',
+      blendMode: 'additive',
+      supportsAdditive: true,
     });
   });
 });

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -581,24 +581,28 @@ export class BakedAnimationController {
       return null;
     }
 
-    const model = this.host.getModel();
-    if (!model) {
-      return null;
-    }
     const additiveClip = new AnimationClip(
-      `${clip.name}__loom3_additive_filtered`,
+      support.keepTracks.length > 0
+        ? `${clip.name}__loom3_additive_filtered`
+        : `${clip.name}__loom3_additive_noop`,
       clip.duration,
       support.keepTracks.map((track) => track.clone())
     );
-    const referenceTracks = support.keepTracks
-      .map((track) => this.createAdditiveReferenceTrack(track, model))
-      .filter((track): track is KeyframeTrack => !!track);
-    const referenceClip = new AnimationClip(
-      `${clip.name}__loom3_additive_reference`,
-      0,
-      referenceTracks
-    );
-    AnimationUtils.makeClipAdditive(additiveClip, 0, referenceClip);
+    if (support.keepTracks.length > 0) {
+      const model = this.host.getModel();
+      if (!model) {
+        return null;
+      }
+      const referenceTracks = support.keepTracks
+        .map((track) => this.createAdditiveReferenceTrack(track, model))
+        .filter((track): track is KeyframeTrack => !!track);
+      const referenceClip = new AnimationClip(
+        `${clip.name}__loom3_additive_reference`,
+        0,
+        referenceTracks
+      );
+      AnimationUtils.makeClipAdditive(additiveClip, 0, referenceClip);
+    }
     this.additiveClipCache.set(clipName, additiveClip);
     return additiveClip;
   }

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -382,11 +382,13 @@ export class BakedAnimationController {
       };
     }
 
+    const bones = this.host.getBones();
     const safeTransformTargets = new Set(
-      Object.values(this.host.getBones())
+      Object.values(bones)
         .map((entry) => entry?.obj)
         .filter(Boolean)
     );
+    const jawTarget = bones.JAW?.obj;
 
     const unsupportedTracks = clip.tracks.filter((track) => {
       const trackName = typeof track?.name === 'string' ? track.name : '';
@@ -429,6 +431,12 @@ export class BakedAnimationController {
       }
 
       if (!safeTransformTargets.has(target)) {
+        return true;
+      }
+
+      // Baked jaw tracks are authored as absolute mouth poses, so additive
+      // playback compounds them against the current pose instead of applying a delta.
+      if (jawTarget && target === jawTarget) {
         return true;
       }
 

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -540,18 +540,8 @@ export class BakedAnimationController {
       ignoredTracks.push(trackName);
     }
 
-    if (keepTracks.length > 0) {
-      return {
-        supported: true,
-        keepTracks,
-        ignoredTracks,
-      };
-    }
-
     return {
-      supported: false,
-      reason: 'unsafe_baked_additive_tracks',
-      unsupportedTracks: ignoredTracks,
+      supported: true,
       keepTracks,
       ignoredTracks,
     };
@@ -587,7 +577,7 @@ export class BakedAnimationController {
     }
 
     const support = this.getAdditiveSupport(clipName, clip);
-    if (!support.supported || support.keepTracks.length === 0) {
+    if (!support.supported) {
       return null;
     }
 

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -193,6 +193,7 @@ export interface BakedAnimationHost {
   computeSideValues: (base: number, balance?: number) => { left: number; right: number };
   getAUMixWeight: (auId: number) => number;
   isMixedAU: (auId: number) => boolean;
+  reapplyProceduralState?: () => void;
 }
 
 // Lightweight unique id for mixer actions/handles
@@ -241,10 +242,6 @@ export class BakedAnimationController {
 
   constructor(host: BakedAnimationHost) {
     this.host = host;
-  }
-
-  private isRootLikeAdditiveTarget(target: Object3D): boolean {
-    return /(armature|boneroot|root|hip|pelvis)/i.test(target.name || '');
   }
 
   private getActionId(action?: AnimationAction | null): string | undefined {
@@ -324,6 +321,69 @@ export class BakedAnimationController {
     for (const clipName of Array.from(this.additiveClipCache.keys())) {
       this.clearFilteredAdditiveClip(clipName);
     }
+  }
+
+  private getMorphTrackBaseValue(
+    target: Object3D | null,
+    propertyIndex: string | number | undefined
+  ): number {
+    if (!target) {
+      return 0;
+    }
+
+    const meshTarget = target as Mesh & {
+      morphTargetInfluences?: number[];
+      morphTargetDictionary?: Record<string, number>;
+    };
+    const influences = meshTarget.morphTargetInfluences;
+    if (!influences) {
+      return 0;
+    }
+
+    let morphIndex: number | undefined;
+    if (typeof propertyIndex === 'number' && Number.isInteger(propertyIndex)) {
+      morphIndex = propertyIndex;
+    } else if (typeof propertyIndex === 'string') {
+      if (/^\d+$/.test(propertyIndex)) {
+        morphIndex = Number(propertyIndex);
+      } else {
+        morphIndex = meshTarget.morphTargetDictionary?.[propertyIndex];
+      }
+    }
+
+    if (morphIndex === undefined) {
+      return 0;
+    }
+
+    return influences[morphIndex] ?? 0;
+  }
+
+  private createAdditiveReferenceTrack(
+    track: KeyframeTrack,
+    model: Object3D
+  ): KeyframeTrack | null {
+    const trackName = typeof track?.name === 'string' ? track.name : '';
+    if (!trackName) {
+      return null;
+    }
+
+    let parsed: ReturnType<typeof PropertyBinding.parseTrackName>;
+    try {
+      parsed = PropertyBinding.parseTrackName(trackName);
+    } catch {
+      return null;
+    }
+
+    const target = this.resolveTrackTarget(model, parsed);
+    if (parsed.propertyName === 'morphTargetInfluences') {
+      return new NumberKeyframeTrack(
+        track.name,
+        [0],
+        [this.getMorphTrackBaseValue(target, parsed.propertyIndex)]
+      );
+    }
+
+    return null;
   }
 
   private normalizePlaybackOptions(
@@ -445,8 +505,7 @@ export class BakedAnimationController {
   }
 
   private analyzeAdditiveSupport(clip: AnimationClip): AdditiveSupport {
-    const model = this.host.getModel();
-    if (!model) {
+    if (!this.host.getModel()) {
       return {
         supported: false,
         reason: 'unsafe_baked_additive_tracks',
@@ -455,13 +514,6 @@ export class BakedAnimationController {
       };
     }
 
-    const bones = this.host.getBones();
-    const safeTransformTargets = new Set(
-      Object.values(bones)
-        .map((entry) => entry?.obj)
-        .filter(Boolean)
-    );
-    const jawTarget = bones.JAW?.obj;
     const keepTracks: KeyframeTrack[] = [];
     const ignoredTracks: string[] = [];
 
@@ -485,33 +537,7 @@ export class BakedAnimationController {
         continue;
       }
 
-      if (parsed.propertyName !== 'quaternion') {
-        ignoredTracks.push(trackName);
-        continue;
-      }
-
-      const target = this.resolveTrackTarget(model, parsed);
-      if (!target || target === model || target.parent === null || (target as any).isCamera) {
-        ignoredTracks.push(trackName);
-        continue;
-      }
-
-      if (!safeTransformTargets.has(target)) {
-        ignoredTracks.push(trackName);
-        continue;
-      }
-
-      if (jawTarget && target === jawTarget) {
-        ignoredTracks.push(trackName);
-        continue;
-      }
-
-      if (this.isRootLikeAdditiveTarget(target)) {
-        ignoredTracks.push(trackName);
-        continue;
-      }
-
-      keepTracks.push(track);
+      ignoredTracks.push(trackName);
     }
 
     if (keepTracks.length > 0) {
@@ -565,12 +591,24 @@ export class BakedAnimationController {
       return null;
     }
 
+    const model = this.host.getModel();
+    if (!model) {
+      return null;
+    }
     const additiveClip = new AnimationClip(
       `${clip.name}__loom3_additive_filtered`,
       clip.duration,
       support.keepTracks.map((track) => track.clone())
     );
-    AnimationUtils.makeClipAdditive(additiveClip);
+    const referenceTracks = support.keepTracks
+      .map((track) => this.createAdditiveReferenceTrack(track, model))
+      .filter((track): track is KeyframeTrack => !!track);
+    const referenceClip = new AnimationClip(
+      `${clip.name}__loom3_additive_reference`,
+      0,
+      referenceTracks
+    );
+    AnimationUtils.makeClipAdditive(additiveClip, 0, referenceClip);
     this.additiveClipCache.set(clipName, additiveClip);
     return additiveClip;
   }
@@ -665,6 +703,23 @@ export class BakedAnimationController {
     return action;
   }
 
+  private hasActiveAdditivePlayback(): boolean {
+    for (const [clipName, action] of this.animationActions) {
+      const state = this.playbackState.get(clipName);
+      if (state?.blendMode !== 'additive') {
+        continue;
+      }
+      if (!action.isRunning() || action.paused) {
+        continue;
+      }
+      if (action.getEffectiveWeight() <= 1e-6) {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+
   private getMeshNamesForAU(auId: number, config: Profile, explicitMeshNames?: string[]): string[] {
     if (explicitMeshNames && explicitMeshNames.length > 0) {
       return explicitMeshNames;
@@ -700,6 +755,9 @@ export class BakedAnimationController {
   update(dtSeconds: number): void {
     if (this.animationMixer) {
       this.animationMixer.update(dtSeconds);
+      if (this.hasActiveAdditivePlayback()) {
+        this.host.reapplyProceduralState?.();
+      }
     }
   }
 
@@ -1028,6 +1086,9 @@ export class BakedAnimationController {
     action.time = Math.max(0, Math.min(duration, Number.isFinite(time) ? time : 0));
     try {
       this.animationMixer?.update(0);
+      if (state.blendMode === 'additive') {
+        this.host.reapplyProceduralState?.();
+      }
     } catch {}
   }
 

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -12,6 +12,7 @@ import {
   KeyframeTrack,
   NumberKeyframeTrack,
   QuaternionKeyframeTrack,
+  VectorKeyframeTrack,
   AdditiveAnimationBlendMode,
   LoopRepeat,
   LoopPingPong,
@@ -201,6 +202,7 @@ const makeActionId = () => `act_${Math.random().toString(36).slice(2, 8)}_${Date
 const X_AXIS = new Vector3(1, 0, 0);
 const Y_AXIS = new Vector3(0, 1, 0);
 const Z_AXIS = new Vector3(0, 0, 1);
+const ADDITIVE_BONE_TRANSFORM_PROPERTIES = new Set(['position', 'quaternion', 'rotation', 'scale']);
 
 type NormalizedPlaybackState = {
   source: AnimationSource;
@@ -358,6 +360,36 @@ export class BakedAnimationController {
     return influences[morphIndex] ?? 0;
   }
 
+  private canCreateFirstFrameReferenceTrack(track: KeyframeTrack): boolean {
+    const valueSize = track.getValueSize();
+    if (!Number.isFinite(valueSize) || valueSize <= 0 || track.values.length < valueSize) {
+      return false;
+    }
+
+    return track.ValueTypeName === 'number'
+      || track.ValueTypeName === 'quaternion'
+      || track.ValueTypeName === 'vector';
+  }
+
+  private createFirstFrameReferenceTrack(track: KeyframeTrack): KeyframeTrack | null {
+    const valueSize = track.getValueSize();
+    if (!this.canCreateFirstFrameReferenceTrack(track)) {
+      return null;
+    }
+
+    const values = Array.from(track.values.slice(0, valueSize));
+    if (track.ValueTypeName === 'number') {
+      return new NumberKeyframeTrack(track.name, [0], values);
+    }
+    if (track.ValueTypeName === 'quaternion') {
+      return new QuaternionKeyframeTrack(track.name, [0], values);
+    }
+    if (track.ValueTypeName === 'vector') {
+      return new VectorKeyframeTrack(track.name, [0], values);
+    }
+    return null;
+  }
+
   private createAdditiveReferenceTrack(
     track: KeyframeTrack,
     model: Object3D
@@ -383,7 +415,8 @@ export class BakedAnimationController {
       );
     }
 
-    return null;
+    // Baked transform tracks are absolute; subtract the clip's first key before additive blending.
+    return this.createFirstFrameReferenceTrack(track);
   }
 
   private normalizePlaybackOptions(
@@ -505,7 +538,8 @@ export class BakedAnimationController {
   }
 
   private analyzeAdditiveSupport(clip: AnimationClip): AdditiveSupport {
-    if (!this.host.getModel()) {
+    const model = this.host.getModel();
+    if (!model) {
       return {
         supported: false,
         reason: 'unsafe_baked_additive_tracks',
@@ -514,6 +548,12 @@ export class BakedAnimationController {
       };
     }
 
+    const bones = this.host.getBones();
+    const resolvedBoneTargets = new Set(
+      Object.values(bones)
+        .map((entry) => entry?.obj)
+        .filter(Boolean)
+    );
     const keepTracks: KeyframeTrack[] = [];
     const ignoredTracks: string[] = [];
 
@@ -532,7 +572,27 @@ export class BakedAnimationController {
         continue;
       }
 
-      if (parsed.propertyName === 'morphTargetInfluences') {
+      if (
+        parsed.propertyName === 'morphTargetInfluences'
+        && track.ValueTypeName === 'number'
+        && this.canCreateFirstFrameReferenceTrack(track)
+      ) {
+        keepTracks.push(track);
+        continue;
+      }
+
+      const target = this.resolveTrackTarget(model, parsed);
+      if (!target || target === model || target.parent === null || (target as any).isCamera) {
+        ignoredTracks.push(trackName);
+        continue;
+      }
+
+      const isBoneTarget = resolvedBoneTargets.has(target) || !!(target as any).isBone;
+      if (
+        isBoneTarget
+        && ADDITIVE_BONE_TRANSFORM_PROPERTIES.has(parsed.propertyName)
+        && this.canCreateFirstFrameReferenceTrack(track)
+      ) {
         keepTracks.push(track);
         continue;
       }

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -8,6 +8,8 @@ import {
   AnimationMixer,
   AnimationAction,
   AnimationClip,
+  AnimationUtils,
+  KeyframeTrack,
   NumberKeyframeTrack,
   QuaternionKeyframeTrack,
   AdditiveAnimationBlendMode,
@@ -217,6 +219,8 @@ type AdditiveSupport = {
   supported: boolean;
   reason?: AnimationBlendModeFallbackReason;
   unsupportedTracks?: string[];
+  keepTracks: KeyframeTrack[];
+  ignoredTracks: string[];
 };
 
 export class BakedAnimationController {
@@ -231,6 +235,7 @@ export class BakedAnimationController {
   private clipSources = new Map<string, AnimationSource>();
   private playbackState = new Map<string, NormalizedPlaybackState>();
   private additiveSupport = new Map<string, AdditiveSupport>();
+  private additiveClipCache = new Map<string, AnimationClip>();
   private actionIds = new WeakMap<AnimationAction, string>();
   private actionIdToClip = new Map<string, string>();
 
@@ -253,6 +258,72 @@ export class BakedAnimationController {
     this.actionIdToClip.set(actionId, clipName);
     action.__actionId = actionId;
     return actionId;
+  }
+
+  private clearActionId(action?: AnimationAction | null): void {
+    if (!action) return;
+    const actionId = this.getActionId(action);
+    if (actionId) {
+      this.actionIdToClip.delete(actionId);
+    }
+    this.actionIds.delete(action);
+    delete action.__actionId;
+  }
+
+  private uncacheAction(action?: AnimationAction | null): void {
+    if (!action || !this.animationMixer) return;
+    try {
+      const clip = action.getClip();
+      if (clip) {
+        this.animationMixer.uncacheAction(clip);
+        this.animationMixer.uncacheClip(clip);
+      }
+    } catch {}
+  }
+
+  private releaseAction(action?: AnimationAction | null): void {
+    if (!action) return;
+    try {
+      action.stop();
+    } catch {}
+    this.uncacheAction(action);
+    this.clearActionId(action);
+  }
+
+  private getBakedClip(clipName: string): AnimationClip | null {
+    return this.animationClips.find((entry) => entry.name === clipName) ?? null;
+  }
+
+  private resolveTrackTarget(
+    model: Object3D,
+    parsed: ReturnType<typeof PropertyBinding.parseTrackName>
+  ): Object3D | null {
+    const targetKey = parsed.objectName === 'bones' && parsed.objectIndex
+      ? parsed.objectIndex
+      : parsed.nodeName;
+    if (!targetKey) {
+      return null;
+    }
+    return model.getObjectByProperty('uuid', targetKey)
+      ?? PropertyBinding.findNode(model, targetKey)
+      ?? null;
+  }
+
+  private clearFilteredAdditiveClip(clipName: string): void {
+    const clip = this.additiveClipCache.get(clipName);
+    if (!clip) return;
+    if (this.animationMixer) {
+      try {
+        this.animationMixer.uncacheClip(clip);
+      } catch {}
+    }
+    this.additiveClipCache.delete(clipName);
+  }
+
+  private clearAllFilteredAdditiveClips(): void {
+    for (const clipName of Array.from(this.additiveClipCache.keys())) {
+      this.clearFilteredAdditiveClip(clipName);
+    }
   }
 
   private normalizePlaybackOptions(
@@ -379,6 +450,8 @@ export class BakedAnimationController {
       return {
         supported: false,
         reason: 'unsafe_baked_additive_tracks',
+        keepTracks: [],
+        ignoredTracks: [],
       };
     }
 
@@ -389,70 +462,72 @@ export class BakedAnimationController {
         .filter(Boolean)
     );
     const jawTarget = bones.JAW?.obj;
+    const keepTracks: KeyframeTrack[] = [];
+    const ignoredTracks: string[] = [];
 
-    const unsupportedTracks = clip.tracks.filter((track) => {
+    for (const track of clip.tracks) {
       const trackName = typeof track?.name === 'string' ? track.name : '';
       if (!trackName) {
-        return true;
+        ignoredTracks.push('[unknown]');
+        continue;
       }
 
       let parsed: ReturnType<typeof PropertyBinding.parseTrackName>;
       try {
         parsed = PropertyBinding.parseTrackName(trackName);
       } catch {
-        return true;
+        ignoredTracks.push(trackName);
+        continue;
       }
 
       if (parsed.propertyName === 'morphTargetInfluences') {
-        return false;
+        keepTracks.push(track);
+        continue;
       }
 
-      if (parsed.propertyName !== 'position' && parsed.propertyName !== 'quaternion') {
-        return true;
+      if (parsed.propertyName !== 'quaternion') {
+        ignoredTracks.push(trackName);
+        continue;
       }
 
-      // Additive translation moves the rig in world/model space and is not safe
-      // for baked playback, even when the target resolves as a known bone.
-      if (parsed.propertyName === 'position') {
-        return true;
-      }
-
-      const targetKey = parsed.objectName === 'bones' && parsed.objectIndex
-        ? parsed.objectIndex
-        : parsed.nodeName;
-      if (!targetKey) {
-        return true;
-      }
-
-      const target = model.getObjectByProperty('uuid', targetKey)
-        ?? PropertyBinding.findNode(model, targetKey);
+      const target = this.resolveTrackTarget(model, parsed);
       if (!target || target === model || target.parent === null || (target as any).isCamera) {
-        return true;
+        ignoredTracks.push(trackName);
+        continue;
       }
 
       if (!safeTransformTargets.has(target)) {
-        return true;
+        ignoredTracks.push(trackName);
+        continue;
       }
 
-      // Baked jaw tracks are authored as absolute mouth poses, so additive
-      // playback compounds them against the current pose instead of applying a delta.
       if (jawTarget && target === jawTarget) {
-        return true;
+        ignoredTracks.push(trackName);
+        continue;
       }
 
-      return this.isRootLikeAdditiveTarget(target);
-    });
+      if (this.isRootLikeAdditiveTarget(target)) {
+        ignoredTracks.push(trackName);
+        continue;
+      }
 
-    if (unsupportedTracks.length === 0) {
-      return { supported: true };
+      keepTracks.push(track);
+    }
+
+    if (keepTracks.length > 0) {
+      return {
+        supported: true,
+        keepTracks,
+        ignoredTracks,
+      };
     }
 
     return {
       supported: false,
       reason: 'unsafe_baked_additive_tracks',
-      unsupportedTracks: unsupportedTracks
-        .map((track) => (typeof track?.name === 'string' ? track.name : ''))
-        .filter(Boolean),
+      unsupportedTracks: ignoredTracks,
+      keepTracks,
+      ignoredTracks,
     };
   }
 
@@ -464,12 +539,40 @@ export class BakedAnimationController {
 
     const resolvedClip = clip ?? this.animationClips.find((entry) => entry.name === clipName);
     if (!resolvedClip) {
-      return { supported: false };
+      return {
+        supported: false,
+        keepTracks: [],
+        ignoredTracks: [],
+      };
     }
 
     const support = this.analyzeAdditiveSupport(resolvedClip);
     this.additiveSupport.set(clipName, support);
     return support;
+  }
+
+  private getOrCreateFilteredAdditiveClip(
+    clipName: string,
+    clip: AnimationClip
+  ): AnimationClip | null {
+    const cached = this.additiveClipCache.get(clipName);
+    if (cached) {
+      return cached;
+    }
+
+    const support = this.getAdditiveSupport(clipName, clip);
+    if (!support.supported || support.keepTracks.length === 0) {
+      return null;
+    }
+
+    const additiveClip = new AnimationClip(
+      `${clip.name}__loom3_additive_filtered`,
+      clip.duration,
+      support.keepTracks.map((track) => track.clone())
+    );
+    AnimationUtils.makeClipAdditive(additiveClip);
+    this.additiveClipCache.set(clipName, additiveClip);
+    return additiveClip;
   }
 
   private sanitizeBakedBlendMode(
@@ -484,8 +587,9 @@ export class BakedAnimationController {
       };
     }
 
-    const support = this.getAdditiveSupport(clipName, clip);
-    if (support.supported) {
+    const bakedClip = clip ?? this.getBakedClip(clipName);
+    const support = this.getAdditiveSupport(clipName, bakedClip);
+    if (bakedClip && support.supported && this.getOrCreateFilteredAdditiveClip(clipName, bakedClip)) {
       return {
         ...state,
         blendMode: 'additive',
@@ -520,20 +624,43 @@ export class BakedAnimationController {
     return 0;
   }
 
-  private getOrCreateBakedAction(clipName: string): AnimationAction | null {
+  private getOrCreateBakedAction(
+    clipName: string,
+    blendMode: AnimationBlendMode = this.getPlaybackStateSnapshot(clipName, {
+      loop: true,
+      source: 'baked',
+    }).blendMode
+  ): AnimationAction | null {
+    const clip = this.getBakedClip(clipName);
+    if (!clip || (this.clipSources.get(clipName) ?? 'baked') !== 'baked') {
+      return null;
+    }
+
+    const desiredClip = blendMode === 'additive'
+      ? this.getOrCreateFilteredAdditiveClip(clipName, clip)
+      : clip;
+    if (!desiredClip) {
+      return null;
+    }
+
     const existing = this.animationActions.get(clipName);
-    if (existing) {
+    if (existing?.getClip() === desiredClip) {
       return existing;
     }
+
     this.ensureMixer();
     if (!this.animationMixer) {
       return null;
     }
-    const clip = this.animationClips.find((entry) => entry.name === clipName);
-    if (!clip || (this.clipSources.get(clipName) ?? 'baked') !== 'baked') {
-      return null;
+
+    if (existing) {
+      this.releaseAction(existing);
     }
-    const action = this.animationMixer.clipAction(clip);
+
+    const action = this.animationMixer.clipAction(desiredClip);
+    if (!this.getActionId(action)) {
+      this.setActionId(action, clipName);
+    }
     this.animationActions.set(clipName, action);
     return action;
   }
@@ -578,6 +705,13 @@ export class BakedAnimationController {
 
   dispose(): void {
     this.stopAllAnimations();
+    for (const action of new Set([
+      ...this.animationActions.values(),
+      ...this.clipActions.values(),
+    ])) {
+      this.clearActionId(action);
+    }
+    this.clearAllFilteredAdditiveClips();
     if (this.animationMixer) {
       this.animationMixer.stopAllAction();
       this.animationMixer = null;
@@ -600,14 +734,11 @@ export class BakedAnimationController {
 
     this.ensureMixer();
     this.animationClips = clips as AnimationClip[];
+    this.additiveSupport.clear();
+    this.clearAllFilteredAdditiveClips();
 
     for (const clip of this.animationClips) {
       this.clipSources.set(clip.name, 'baked');
-      this.additiveSupport.set(clip.name, this.analyzeAdditiveSupport(clip));
-      if (!this.animationActions.has(clip.name) && this.animationMixer) {
-        const action = this.animationMixer.clipAction(clip);
-        this.animationActions.set(clip.name, action);
-      }
     }
   }
 
@@ -623,7 +754,7 @@ export class BakedAnimationController {
   }
 
   removeAnimationClip(clipName: string): boolean {
-    const clip = this.animationClips.find((entry) => entry.name === clipName);
+    const clip = this.getBakedClip(clipName);
     if (!clip || (this.clipSources.get(clipName) ?? 'baked') !== 'baked') {
       return false;
     }
@@ -636,21 +767,15 @@ export class BakedAnimationController {
 
     this.stopAnimation(clipName);
 
-    if (this.animationMixer) {
-      for (const action of relatedActions) {
-        try {
-          this.animationMixer.uncacheAction(clip);
-        } catch {}
-        try {
-          this.animationMixer.uncacheClip(clip);
-        } catch {}
-        const actionId = this.getActionId(action);
-        if (actionId) {
-          this.actionIdToClip.delete(actionId);
-        }
-        this.actionIds.delete(action);
-      }
+    for (const action of relatedActions) {
+      this.releaseAction(action);
     }
+    if (this.animationMixer) {
+      try {
+        this.animationMixer.uncacheClip(clip);
+      } catch {}
+    }
+    this.clearFilteredAdditiveClip(clipName);
 
     this.animationClips = this.animationClips.filter((entry) => entry.name !== clipName);
     this.animationActions.delete(clipName);
@@ -665,26 +790,28 @@ export class BakedAnimationController {
   }
 
   playAnimation(clipName: string, options: AnimationPlayOptions = {}): AnimationActionHandle | null {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (!action) {
+    const clip = this.getBakedClip(clipName);
+    if (!clip) {
       console.warn(`Loom3: Animation clip "${clipName}" not found`);
       return null;
-    }
-    if (!this.getActionId(action)) {
-      this.setActionId(action, clipName);
     }
 
     const playbackState = this.sanitizeBakedBlendMode(
       clipName,
       this.mergePlaybackOptions(
-      this.getPlaybackStateSnapshot(clipName, { loop: true, source: 'baked' }),
-      options
+        this.getPlaybackStateSnapshot(clipName, { loop: true, source: 'baked' }),
+        options
       ),
-      action.getClip()
+      clip
     );
+    const action = this.getOrCreateBakedAction(clipName, playbackState.blendMode);
+    if (!action) {
+      console.warn(`Loom3: Animation clip "${clipName}" not found`);
+      return null;
+    }
     const crossfadeDuration = options.crossfadeDuration ?? 0;
     const clampWhenFinished = options.clampWhenFinished ?? playbackState.loopMode === 'once';
-    const startTime = this.resolveStartTime(action.getClip().duration, playbackState, options.startTime);
+    const startTime = this.resolveStartTime(clip.duration, playbackState, options.startTime);
 
     this.applyPlaybackState(action, playbackState);
     action.clampWhenFinished = clampWhenFinished;
@@ -796,38 +923,36 @@ export class BakedAnimationController {
   }
 
   setAnimationSpeed(clipName: string, speed: number): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (action) {
-      const next = this.getPlaybackStateSnapshot(clipName, {
-        loop: true,
-        source: this.clipSources.get(clipName) ?? 'baked',
-      });
-      next.playbackRate = Number.isFinite(speed) ? Math.max(0, Math.abs(speed)) : 1.0;
-      this.applyPlaybackState(action, next);
-      this.setPlaybackState(clipName, next);
-    }
-  }
-
-  setAnimationIntensity(clipName: string, intensity: number): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (action) {
-      const next = this.getPlaybackStateSnapshot(clipName, {
-        loop: true,
-        source: this.clipSources.get(clipName) ?? 'baked',
-      });
-      next.weight = Number.isFinite(intensity) ? Math.max(0, intensity) : 1.0;
-      action.setEffectiveWeight(next.weight);
-      this.setPlaybackState(clipName, next);
-    }
-  }
-
-  setAnimationLoopMode(clipName: string, loopMode: 'repeat' | 'once' | 'pingpong'): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (!action) return;
     const next = this.getPlaybackStateSnapshot(clipName, {
       loop: true,
       source: this.clipSources.get(clipName) ?? 'baked',
     });
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
+    next.playbackRate = Number.isFinite(speed) ? Math.max(0, Math.abs(speed)) : 1.0;
+    this.applyPlaybackState(action, next);
+    this.setPlaybackState(clipName, next);
+  }
+
+  setAnimationIntensity(clipName: string, intensity: number): void {
+    const next = this.getPlaybackStateSnapshot(clipName, {
+      loop: true,
+      source: this.clipSources.get(clipName) ?? 'baked',
+    });
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
+    next.weight = Number.isFinite(intensity) ? Math.max(0, intensity) : 1.0;
+    action.setEffectiveWeight(next.weight);
+    this.setPlaybackState(clipName, next);
+  }
+
+  setAnimationLoopMode(clipName: string, loopMode: 'repeat' | 'once' | 'pingpong'): void {
+    const next = this.getPlaybackStateSnapshot(clipName, {
+      loop: true,
+      source: this.clipSources.get(clipName) ?? 'baked',
+    });
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
     next.loopMode = loopMode;
     next.loop = loopMode !== 'once';
     this.applyPlaybackState(action, next);
@@ -835,12 +960,12 @@ export class BakedAnimationController {
   }
 
   setAnimationRepeatCount(clipName: string, repeatCount?: number): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (!action) return;
     const next = this.getPlaybackStateSnapshot(clipName, {
       loop: true,
       source: this.clipSources.get(clipName) ?? 'baked',
     });
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
     next.repeatCount = typeof repeatCount === 'number' && Number.isFinite(repeatCount)
       ? Math.max(0, repeatCount)
       : undefined;
@@ -849,20 +974,22 @@ export class BakedAnimationController {
   }
 
   setAnimationReverse(clipName: string, reverse: boolean): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (!action) return;
     const next = this.getPlaybackStateSnapshot(clipName, {
       loop: true,
       source: this.clipSources.get(clipName) ?? 'baked',
     });
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
     next.reverse = !!reverse;
     this.applyPlaybackState(action, next);
     this.setPlaybackState(clipName, next);
   }
 
   setAnimationBlendMode(clipName: string, blendMode: AnimationBlendMode): void {
-    const action = this.getOrCreateBakedAction(clipName);
-    if (!action) return;
+    const clip = this.getBakedClip(clipName);
+    const currentAction = this.animationActions.get(clipName);
+    if (!clip || !currentAction) return;
+
     const next = this.sanitizeBakedBlendMode(
       clipName,
       {
@@ -873,14 +1000,29 @@ export class BakedAnimationController {
         requestedBlendMode: blendMode,
         blendMode,
       },
-      action.getClip()
+      clip
     );
+    const previousTime = currentAction.time;
+    const wasRunning = currentAction.isRunning();
+    const wasPaused = currentAction.paused;
+    const action = this.getOrCreateBakedAction(clipName, next.blendMode);
+    if (!action) return;
+
     this.applyPlaybackState(action, next);
+    action.time = Math.max(0, Math.min(action.getClip().duration, previousTime));
+    if (wasRunning) {
+      action.play();
+    }
+    action.paused = wasPaused;
     this.setPlaybackState(clipName, next);
   }
 
   seekAnimation(clipName: string, time: number): void {
-    const action = this.getOrCreateBakedAction(clipName) ?? this.animationActions.get(clipName);
+    const state = this.getPlaybackStateSnapshot(clipName, {
+      loop: true,
+      source: this.clipSources.get(clipName) ?? 'baked',
+    });
+    const action = this.getOrCreateBakedAction(clipName, state.blendMode) ?? this.animationActions.get(clipName);
     if (!action) return;
     const duration = action.getClip().duration;
     action.time = Math.max(0, Math.min(duration, Number.isFinite(time) ? time : 0));
@@ -901,15 +1043,15 @@ export class BakedAnimationController {
 
     const clip = action.getClip();
     const state = this.playbackState.get(clipName);
-    const additiveSupport = this.getAdditiveSupport(clipName, clip);
+    const additiveSupport = this.getAdditiveSupport(clipName, this.getBakedClip(clipName) ?? clip);
     const loopMode = state?.loopMode
       ?? (action.loop === LoopPingPong ? 'pingpong' : action.loop === LoopOnce ? 'once' : 'repeat');
     const playbackRate = state?.playbackRate ?? Math.abs(action.getEffectiveTimeScale());
     const reverse = state?.reverse ?? action.getEffectiveTimeScale() < 0;
     return {
-      name: clip.name,
+      name: clipName,
       actionId: this.getActionId(action),
-      source: state?.source ?? this.clipSources.get(clip.name) ?? 'baked',
+      source: state?.source ?? this.clipSources.get(clipName) ?? 'baked',
       isPlaying: action.isRunning() && !action.paused,
       isPaused: action.paused,
       time: action.time,

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -196,6 +196,7 @@ export class Loom3 implements LoomLarge {
       computeSideValues: (base, balance) => this.computeSideValues(base, balance),
       getAUMixWeight: (auId) => this.getAUMixWeight(auId),
       isMixedAU: (auId) => this.isMixedAU(auId),
+      reapplyProceduralState: () => this.reapplyProceduralStateAfterBakedUpdate(),
     });
 
     this.hairPhysics = new HairPhysicsController({
@@ -1040,6 +1041,36 @@ export class Loom3 implements LoomLarge {
       this.flushPendingComposites();
       this.model.updateMatrixWorld(true);
     }
+  }
+
+  private reapplyProceduralStateAfterBakedUpdate(): void {
+    if (!this.model) {
+      return;
+    }
+
+    let hasActiveOverrides = false;
+
+    for (const [auIdStr, value] of Object.entries(this.auValues)) {
+      if (value <= 0) continue;
+      const auId = Number(auIdStr);
+      if (Number.isNaN(auId)) continue;
+      hasActiveOverrides = true;
+      this.setAU(auId, value, this.auBalances[auId]);
+    }
+
+    for (let visemeIndex = 0; visemeIndex < this.visemeValues.length; visemeIndex += 1) {
+      const value = this.visemeValues[visemeIndex] ?? 0;
+      if (value <= 0) continue;
+      hasActiveOverrides = true;
+      this.setViseme(visemeIndex, value, this.visemeJawScales[visemeIndex] ?? 1);
+    }
+
+    if (!hasActiveOverrides) {
+      return;
+    }
+
+    this.flushPendingComposites();
+    this.model.updateMatrixWorld(true);
   }
 
   // ============================================================================


### PR DESCRIPTION
## Summary
This PR makes baked animation clips safe in additive mode by converting eligible baked tracks into true additive deltas instead of applying absolute transforms additively.

## What Changed

- Analyze baked additive clips track-by-track.
- Keep morph target tracks additive relative to the current neutral mesh value.
- Keep bone transform tracks (`position`, `rotation`, `quaternion`, `scale`) for resolved Loom3 bones and real Three.js `Bone` targets.
- Convert kept bone transform tracks against the clip's first keyframe before additive blending, so the clip contributes motion deltas instead of fighting the base pose.
- Continue filtering root/model/camera/unresolved/non-bone tracks from baked additive playback.
- Keep additive mode selectable even when filtering leaves an additive no-op clip.
- Switch baked actions to the filtered/converted additive clip when additive mode is requested or toggled after playback starts.

## Behavior

- `blendMode: "replace"` continues to play the original baked clip exactly as authored.
- `blendMode: "additive"` now preserves bone-only baked animation motion as deltas instead of dropping the animation or double-applying absolute poses.
- Root/global/problematic tracks are removed from the additive clone rather than blocking the additive toggle.

## Validation

- `npm test -- src/engines/three/AnimationThree.playbackState.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

## Notes

Stacked on top of `pm/105-baked-additive-safety`. Linked LoomLarge validation PR: meekmachine/LoomLarge#437.