### PR TITLE
Add runtime morph target authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,25 @@ const targets = loom.resolveMorphTargets('Mouth_Smile_L', ['CC_Base_Body']);
 const value = targets.length > 0 ? (targets[0].infl[targets[0].idx] ?? 0) : 0;
 ```
 
+### Adding runtime morph targets
+
+Generated or sidecar morph targets can be registered after a model loads. Deltas use the same relative `POSITION` format as glTF morph targets: one XYZ delta per base mesh vertex. Optional `normal` and `tangent` deltas can be supplied when available.
+
+```typescript
+const index = loom.addMorphTarget({
+  meshName: 'CC_Base_Body',
+  name: 'BodyType_Muscular',
+  position: bodyTypeMuscularDeltas,
+});
+
+loom.setMorphInfluence(index, 0.6, ['CC_Base_Body']);
+loom.setMorph('BodyType_Muscular', 0.6, ['CC_Base_Body']);
+```
+
+By default, Loom3 replaces and disposes the mesh `BufferGeometry` before appending morph attributes. This is intentional: Three.js does not support mutating `geometry.morphAttributes` in place after a geometry has rendered. For pre-render authoring paths, pass `{ forceGeometryReplacement: false }`.
+
+If you need a named slot before real deltas are available, use `ensureMorphInfluence(meshName, morphName)`. It creates a zero-delta target and returns the assigned `morphTargetInfluences` index. After external code changes morph dictionaries or geometry, call `refreshMorphTargets()` so AU, viseme, hair, and clip-building caches see the updated targets.
+
 ### Morph caching
 
 Loom3 caches morph target lookups for performance. The first time you access a morph, it searches all meshes and caches the index. Subsequent accesses are O(1).
@@ -2128,6 +2147,7 @@ This is a compact reference for the public surface exported by `@lovelace_lol/lo
 - Lifecycle: `onReady()`, `update()`, `start()`, `stop()`, `dispose()`.
 - Preset state: `setProfile()`, `getProfile()`.
 - Control APIs: `setAU()`, `transitionAU()`, `setContinuum()`, `transitionContinuum()`, `setMorph()`, `transitionMorph()`, `setViseme()`, `transitionViseme()`.
+- Runtime morph authoring: `addMorphTarget()`, `addMorphTargets()`, `ensureMorphInfluence()`, `refreshMorphTargets()`.
 - Transition state: `pause()`, `resume()`, `getPaused()`, `clearTransitions()`, `getActiveTransitionCount()`, `resetToNeutral()`.
 
 ### Presets and profiles

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -91,6 +91,40 @@ export interface Loom3Config {
 }
 
 // ============================================================================
+// RUNTIME MORPH TARGET AUTHORING
+// ============================================================================
+
+export type MorphTargetAttributeData = Float32Array | number[];
+
+export interface MorphTargetDelta {
+  /** Mesh name from the loaded Three.js scene. */
+  meshName: string;
+  /** Morph target name to add to morphTargetDictionary. */
+  name: string;
+  /** POSITION deltas, usually XYZ values relative to the base mesh. */
+  position: MorphTargetAttributeData;
+  /** Optional NORMAL deltas. */
+  normal?: MorphTargetAttributeData;
+  /** Optional TANGENT deltas. */
+  tangent?: MorphTargetAttributeData;
+  /** Whether deltas are relative to base attributes. Defaults to true. */
+  relative?: boolean;
+}
+
+export interface AddMorphTargetOptions {
+  /** Replace an existing morph target with the same name. */
+  replace?: boolean;
+  /** Initialize the new or replaced influence value to zero. Defaults to true. */
+  resetInfluence?: boolean;
+  /**
+   * Replace and dispose the BufferGeometry instead of mutating it in place.
+   * Defaults to true because Three.js does not support mutating morph attributes
+   * after a geometry has rendered.
+   */
+  forceGeometryReplacement?: boolean;
+}
+
+// ============================================================================
 // BAKED ANIMATION TYPES (Three.js AnimationMixer support)
 // ============================================================================
 

--- a/src/engines/three/Loom3.morphAuthoring.test.ts
+++ b/src/engines/three/Loom3.morphAuthoring.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BufferAttribute, BufferGeometry, Mesh, MeshBasicMaterial, Object3D } from 'three';
+import { Loom3, collectMorphMeshes } from './Loom3';
+import { analyzeModel } from '../../validation/analyzeModel';
+
+function makeGeometry(): BufferGeometry {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute('position', new BufferAttribute(new Float32Array([
+    0, 0, 0,
+    1, 0, 0,
+    0, 1, 0,
+  ]), 3));
+  return geometry;
+}
+
+function makeMesh(name: string, morphs: Record<string, Float32Array> = {}): Mesh {
+  const geometry = makeGeometry();
+  const mesh = new Mesh(geometry, new MeshBasicMaterial());
+  mesh.name = name;
+
+  const entries = Object.entries(morphs);
+  if (entries.length > 0) {
+    geometry.morphAttributes.position = entries.map(([morphName, values]) => {
+      const attribute = new BufferAttribute(values, 3);
+      (attribute as any).name = morphName;
+      return attribute;
+    });
+    geometry.morphTargetsRelative = true;
+    mesh.morphTargetDictionary = Object.fromEntries(entries.map(([morphName], index) => [morphName, index]));
+    mesh.morphTargetInfluences = new Array(entries.length).fill(0);
+  }
+
+  return mesh;
+}
+
+const smileDelta = new Float32Array([
+  0, 0.1, 0,
+  0, 0.1, 0,
+  0, 0.1, 0,
+]);
+
+const bodyDelta = new Float32Array([
+  0.1, 0, 0,
+  0.1, 0, 0,
+  0.1, 0, 0,
+]);
+
+describe('Loom3 runtime morph target authoring', () => {
+  it('adds a named morph target and drives it by key and influence index', () => {
+    const face = makeMesh('FaceMesh', { ExistingSmile: smileDelta });
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [face] });
+
+    const index = engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'CustomSmile',
+      position: bodyDelta,
+    }, { forceGeometryReplacement: false });
+
+    expect(index).toBe(1);
+    expect(face.morphTargetDictionary?.CustomSmile).toBe(1);
+    expect(face.morphTargetInfluences).toEqual([0, 0]);
+
+    engine.setMorph('CustomSmile', 0.75, ['FaceMesh']);
+    expect(face.morphTargetInfluences?.[1]).toBe(0.75);
+
+    engine.setMorphInfluence(1, 0.25, ['FaceMesh']);
+    expect(face.morphTargetInfluences?.[1]).toBe(0.25);
+  });
+
+  it('uses geometry replacement by default for post-render-safe mutation', () => {
+    const face = makeMesh('FaceMesh', { ExistingSmile: smileDelta });
+    const oldGeometry = face.geometry;
+    const dispose = vi.spyOn(oldGeometry, 'dispose');
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [face] });
+
+    engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'AfterRenderMorph',
+      position: bodyDelta,
+    });
+
+    expect(face.geometry).not.toBe(oldGeometry);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(face.morphTargetDictionary?.AfterRenderMorph).toBe(1);
+    expect(face.morphTargetInfluences).toEqual([0, 0]);
+  });
+
+  it('creates the first morph influence slot on a static mesh', async () => {
+    const body = makeMesh('BodyMesh');
+    const model = new Object3D();
+    model.add(body);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['BodyMesh'] } },
+    });
+    engine.onReady({ model, meshes: [] });
+
+    const index = engine.ensureMorphInfluence('BodyMesh', 'BodyType_Muscular');
+    expect(index).toBe(0);
+
+    engine.setMorph('BodyType_Muscular', 1, ['BodyMesh']);
+    expect(body.morphTargetInfluences?.[0]).toBe(1);
+    expect(collectMorphMeshes(model)).toEqual([body]);
+
+    const report = await analyzeModel({
+      source: { type: 'runtime', model, meshes: collectMorphMeshes(model), animations: [] },
+    });
+    expect(report.model.morphNames).toContain('BodyType_Muscular');
+  });
+
+  it('rebuilds AU morph caches after adding a previously missing target', () => {
+    const face = makeMesh('FaceMesh');
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: {
+        morphToMesh: { face: ['FaceMesh'] },
+        auToMorphs: { 999: { left: [], right: [], center: ['GeneratedAU999'] } },
+      },
+    });
+    engine.onReady({ model, meshes: [] });
+    engine.setAU(999, 1);
+
+    engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'GeneratedAU999',
+      position: bodyDelta,
+    });
+
+    expect(face.morphTargetInfluences?.[0]).toBe(1);
+  });
+
+  it('rejects morph deltas with the wrong vertex count', () => {
+    const face = makeMesh('FaceMesh');
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [] });
+
+    expect(() => engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'BadMorph',
+      position: new Float32Array([0, 1, 2]),
+    })).toThrow(/expected 9/);
+  });
+});

--- a/src/engines/three/Loom3.morphAuthoring.test.ts
+++ b/src/engines/three/Loom3.morphAuthoring.test.ts
@@ -10,6 +10,11 @@ function makeGeometry(): BufferGeometry {
     1, 0, 0,
     0, 1, 0,
   ]), 3));
+  geometry.setAttribute('normal', new BufferAttribute(new Float32Array([
+    0, 0, 1,
+    0, 0, 1,
+    0, 0, 1,
+  ]), 3));
   return geometry;
 }
 
@@ -97,6 +102,35 @@ describe('Loom3 runtime morph target authoring', () => {
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(face.morphTargetDictionary?.AfterRenderMorph).toBe(1);
     expect(face.morphTargetInfluences).toEqual([0, 0]);
+  });
+
+  it('keeps existing morph attribute streams aligned for position-only targets', () => {
+    const face = makeMesh('FaceMesh', { ExistingSmile: smileDelta });
+    face.geometry.morphAttributes.normal = [
+      new BufferAttribute(new Float32Array([
+        0, 0, 0.1,
+        0, 0, 0.1,
+        0, 0, 0.1,
+      ]), 3),
+    ];
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [face] });
+
+    engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'BodyWidth',
+      position: bodyDelta,
+    });
+
+    const normalMorphs = face.geometry.morphAttributes.normal;
+    expect(normalMorphs).toHaveLength(2);
+    expect(normalMorphs?.[1]?.array).toEqual(new Float32Array(9));
   });
 
   it('creates the first morph influence slot on a static mesh', async () => {

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -1594,22 +1594,39 @@ export class Loom3 implements LoomLarge {
     const geometry = forceGeometryReplacement ? sourceGeometry.clone() : sourceGeometry;
     const dictionary = { ...previousDictionary };
     const usedIndices = Object.values(dictionary).filter(Number.isInteger);
-    const existingPositionTargetCount = geometry.morphAttributes.position?.length ?? 0;
-    const nextIndex = Math.max(existingPositionTargetCount, usedIndices.length ? Math.max(...usedIndices) + 1 : 0);
+    const existingAttributeTargetCount = Math.max(
+      0,
+      ...Object.values(geometry.morphAttributes).map((attributes) => attributes?.length ?? 0)
+    );
+    const nextIndex = Math.max(existingAttributeTargetCount, usedIndices.length ? Math.max(...usedIndices) + 1 : 0);
     const index = existingIndex ?? nextIndex;
     dictionary[target.name] = index;
 
     this.setMorphAttributeAtIndex(geometry, 'position', target.position, position.itemSize, position.count, index, target.name);
 
+    const normal = geometry.getAttribute('normal');
     if (target.normal) {
-      const normal = geometry.getAttribute('normal');
       this.setMorphAttributeAtIndex(geometry, 'normal', target.normal, normal?.itemSize ?? 3, position.count, index, target.name);
+    } else {
+      this.setZeroMorphAttributeAtIndex(geometry, 'normal', normal?.itemSize ?? 3, position.count, index, target.name);
     }
 
+    const tangent = geometry.getAttribute('tangent');
     if (target.tangent) {
-      const tangent = geometry.getAttribute('tangent');
       this.setMorphAttributeAtIndex(geometry, 'tangent', target.tangent, tangent?.itemSize ?? 4, position.count, index, target.name);
+    } else {
+      this.setZeroMorphAttributeAtIndex(geometry, 'tangent', tangent?.itemSize ?? 4, position.count, index, target.name);
     }
+    const color = geometry.getAttribute('color');
+    const existingColorMorph = geometry.morphAttributes.color?.find(Boolean);
+    this.setZeroMorphAttributeAtIndex(
+      geometry,
+      'color',
+      color?.itemSize ?? existingColorMorph?.itemSize ?? 3,
+      position.count,
+      index,
+      target.name
+    );
 
     geometry.morphTargetsRelative = target.relative !== false;
     (geometry as any).morphTargetDictionary = dictionary;
@@ -1673,7 +1690,7 @@ export class Loom3 implements LoomLarge {
 
   private setMorphAttributeAtIndex(
     geometry: Mesh['geometry'],
-    semantic: 'position' | 'normal' | 'tangent',
+    semantic: string,
     data: Float32Array | number[],
     itemSize: number,
     vertexCount: number,
@@ -1699,6 +1716,30 @@ export class Loom3 implements LoomLarge {
     const attribute = new BufferAttribute(values, itemSize);
     (attribute as any).name = name;
     attributes[index] = attribute;
+    geometry.morphAttributes[semantic] = attributes;
+  }
+
+  private setZeroMorphAttributeAtIndex(
+    geometry: Mesh['geometry'],
+    semantic: string,
+    itemSize: number,
+    vertexCount: number,
+    index: number,
+    name: string
+  ): void {
+    if (!geometry.morphAttributes[semantic]?.length) return;
+
+    const expectedLength = vertexCount * itemSize;
+    const attributes = [...geometry.morphAttributes[semantic]];
+    while (attributes.length < index) {
+      const empty = new BufferAttribute(new Float32Array(expectedLength), itemSize);
+      (empty as any).name = `morph_${attributes.length}`;
+      attributes.push(empty);
+    }
+
+    const empty = new BufferAttribute(new Float32Array(expectedLength), itemSize);
+    (empty as any).name = name;
+    attributes[index] = empty;
     geometry.morphAttributes[semantic] = attributes;
   }
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  BufferAttribute,
   Quaternion,
   Vector3,
   Box3,
@@ -32,9 +33,11 @@ import type {
   ClipHandle,
   Snippet,
   CompositeRotation,
-    RotationAxis,
-    AnimationBlendMode,
-  } from '../../core/types';
+  RotationAxis,
+  AnimationBlendMode,
+  MorphTargetDelta,
+  AddMorphTargetOptions,
+} from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
 import { AnimationThree, BakedAnimationController } from './AnimationThree';
 import { getSideScale } from './balanceUtils';
@@ -234,14 +237,11 @@ export class Loom3 implements LoomLarge {
     this.morphKeyCache.clear();
     this.morphIndexCache.clear();
 
-    // Build mesh lookup
+    // Build mesh lookup. Keep all named meshes addressable so runtime morph
+    // authoring can add the first morph target to a previously static mesh.
     model.traverse((obj: any) => {
       if (obj.isMesh && obj.name) {
-        const infl = obj.morphTargetInfluences;
-        const dict = obj.morphTargetDictionary;
-        if ((Array.isArray(infl) && infl.length > 0) || (dict && Object.keys(dict).length > 0)) {
-          this.meshByName.set(obj.name, obj);
-        }
+        this.meshByName.set(obj.name, obj);
       }
     });
 
@@ -723,6 +723,65 @@ export class Loom3 implements LoomLarge {
   // ============================================================================
   // MORPH CONTROL
   // ============================================================================
+
+  addMorphTarget(target: MorphTargetDelta, options: AddMorphTargetOptions = {}): number {
+    const staleMorphTargets = this.collectResolvedExpressionMorphTargets();
+    const index = this.applyMorphTargetDelta(target, options);
+    this.refreshMorphTargets([target.meshName]);
+    this.reinitializeRuntimeStateFromCurrentControls(staleMorphTargets);
+    return index;
+  }
+
+  addMorphTargets(targets: MorphTargetDelta[], options: AddMorphTargetOptions = {}): Record<string, number> {
+    const staleMorphTargets = this.collectResolvedExpressionMorphTargets();
+    const result: Record<string, number> = {};
+
+    for (const target of targets) {
+      const index = this.applyMorphTargetDelta(target, options);
+      result[`${target.meshName}:${target.name}`] = index;
+    }
+
+    this.refreshMorphTargets(Array.from(new Set(targets.map((target) => target.meshName))));
+    this.reinitializeRuntimeStateFromCurrentControls(staleMorphTargets);
+    return result;
+  }
+
+  ensureMorphInfluence(meshName: string, morphName: string): number {
+    const mesh = this.requireNamedMesh(meshName);
+    const dict = this.getMeshMorphDictionary(mesh);
+    const existing = dict[morphName];
+    if (existing !== undefined) return existing;
+
+    const position = mesh.geometry.getAttribute('position');
+    if (!position) {
+      throw new Error(`Cannot create morph target "${morphName}" on mesh "${meshName}": geometry has no position attribute.`);
+    }
+
+    return this.addMorphTarget({
+      meshName,
+      name: morphName,
+      position: new Float32Array(position.count * position.itemSize),
+      relative: true,
+    });
+  }
+
+  refreshMorphTargets(_meshNames?: string[]): void {
+    this.morphKeyCache.clear();
+    this.morphIndexCache.clear();
+
+    if (this.model) {
+      this.meshByName.clear();
+      this.model.traverse((obj: any) => {
+        if (obj.isMesh && obj.name) {
+          this.meshByName.set(obj.name, obj);
+        }
+      });
+      this.meshes = collectMorphMeshes(this.model);
+    }
+
+    this.rebuildMorphTargetsCache();
+    this.hairPhysics.refreshMeshSelection();
+  }
 
   /**
    * Set a morph target value.
@@ -1508,6 +1567,147 @@ export class Loom3 implements LoomLarge {
       if (idx < infl.length) return infl[idx] ?? 0;
     }
     return 0;
+  }
+
+  private applyMorphTargetDelta(target: MorphTargetDelta, options: AddMorphTargetOptions): number {
+    const mesh = this.requireNamedMesh(target.meshName);
+    const sourceGeometry = mesh.geometry;
+    const position = sourceGeometry.getAttribute('position');
+    if (!position) {
+      throw new Error(`Cannot add morph target "${target.name}" to mesh "${target.meshName}": geometry has no position attribute.`);
+    }
+    if (!target.name || !target.name.trim()) {
+      throw new Error(`Cannot add morph target to mesh "${target.meshName}": target name is required.`);
+    }
+
+    const replace = options.replace === true;
+    const resetInfluence = options.resetInfluence !== false;
+    const forceGeometryReplacement = options.forceGeometryReplacement !== false;
+    const previousInfluences = mesh.morphTargetInfluences ? [...mesh.morphTargetInfluences] : [];
+    const previousDictionary = this.getMeshMorphDictionary(mesh);
+    const existingIndex = previousDictionary[target.name];
+
+    if (existingIndex !== undefined && !replace) {
+      throw new Error(`Morph target "${target.name}" already exists on mesh "${target.meshName}". Pass replace: true to overwrite it.`);
+    }
+
+    const geometry = forceGeometryReplacement ? sourceGeometry.clone() : sourceGeometry;
+    const dictionary = { ...previousDictionary };
+    const usedIndices = Object.values(dictionary).filter(Number.isInteger);
+    const existingPositionTargetCount = geometry.morphAttributes.position?.length ?? 0;
+    const nextIndex = Math.max(existingPositionTargetCount, usedIndices.length ? Math.max(...usedIndices) + 1 : 0);
+    const index = existingIndex ?? nextIndex;
+    dictionary[target.name] = index;
+
+    this.setMorphAttributeAtIndex(geometry, 'position', target.position, position.itemSize, position.count, index, target.name);
+
+    if (target.normal) {
+      const normal = geometry.getAttribute('normal');
+      this.setMorphAttributeAtIndex(geometry, 'normal', target.normal, normal?.itemSize ?? 3, position.count, index, target.name);
+    }
+
+    if (target.tangent) {
+      const tangent = geometry.getAttribute('tangent');
+      this.setMorphAttributeAtIndex(geometry, 'tangent', target.tangent, tangent?.itemSize ?? 4, position.count, index, target.name);
+    }
+
+    geometry.morphTargetsRelative = target.relative !== false;
+    (geometry as any).morphTargetDictionary = dictionary;
+
+    if (forceGeometryReplacement) {
+      mesh.geometry = geometry;
+      sourceGeometry.dispose();
+    }
+
+    const influenceLength = Math.max(previousInfluences.length, index + 1);
+    const influences = previousInfluences.slice(0, influenceLength);
+    while (influences.length < influenceLength) {
+      influences.push(0);
+    }
+    if (resetInfluence) {
+      influences[index] = 0;
+    }
+
+    mesh.morphTargetDictionary = dictionary;
+    mesh.morphTargetInfluences = influences;
+    this.addRuntimeMorphMesh(mesh);
+
+    if (!this.config.morphToMesh?.face?.length) {
+      this.config.morphToMesh = {
+        ...this.config.morphToMesh,
+        face: [mesh.name],
+      };
+    }
+
+    return index;
+  }
+
+  private requireNamedMesh(meshName: string): Mesh {
+    const mesh = this.meshByName.get(meshName);
+    if (mesh) return mesh;
+
+    if (this.model) {
+      let found: Mesh | null = null;
+      this.model.traverse((obj: any) => {
+        if (!found && obj.isMesh && obj.name === meshName) {
+          found = obj as Mesh;
+        }
+      });
+      if (found) {
+        this.meshByName.set(meshName, found);
+        return found;
+      }
+    }
+
+    throw new Error(`Mesh "${meshName}" was not found in the current model.`);
+  }
+
+  private getMeshMorphDictionary(mesh: Mesh): Record<string, number> {
+    const meshDictionary = mesh.morphTargetDictionary as Record<string, number> | undefined;
+    const geometryDictionary = (mesh.geometry as any).morphTargetDictionary as Record<string, number> | undefined;
+    const dictionary = meshDictionary || geometryDictionary || {};
+    mesh.morphTargetDictionary = dictionary;
+    (mesh.geometry as any).morphTargetDictionary = dictionary;
+    return dictionary;
+  }
+
+  private setMorphAttributeAtIndex(
+    geometry: Mesh['geometry'],
+    semantic: 'position' | 'normal' | 'tangent',
+    data: Float32Array | number[],
+    itemSize: number,
+    vertexCount: number,
+    index: number,
+    name: string
+  ): void {
+    const expectedLength = vertexCount * itemSize;
+    if (data.length !== expectedLength) {
+      throw new Error(
+        `Morph target "${name}" ${semantic} data has ${data.length} values; expected ${expectedLength} ` +
+        `(${vertexCount} vertices * itemSize ${itemSize}).`
+      );
+    }
+
+    const attributes = geometry.morphAttributes[semantic] ? [...geometry.morphAttributes[semantic]] : [];
+    while (attributes.length < index) {
+      const empty = new BufferAttribute(new Float32Array(expectedLength), itemSize);
+      (empty as any).name = `morph_${attributes.length}`;
+      attributes.push(empty);
+    }
+
+    const values = data instanceof Float32Array ? new Float32Array(data) : Float32Array.from(data);
+    const attribute = new BufferAttribute(values, itemSize);
+    (attribute as any).name = name;
+    attributes[index] = attribute;
+    geometry.morphAttributes[semantic] = attributes;
+  }
+
+  private addRuntimeMorphMesh(mesh: Mesh): void {
+    const key = mesh.name || (mesh as any).uuid;
+    const exists = this.meshes.some((candidate) => (candidate.name || (candidate as any).uuid) === key);
+    if (!exists) {
+      this.meshes.push(mesh);
+    }
   }
 
   private getMorphKeyCacheKey(key: string, meshNames?: string[]): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,9 @@ export type {
   ClipEventListener,
   ClipHandle,
   Snippet,
+  MorphTargetAttributeData,
+  MorphTargetDelta,
+  AddMorphTargetOptions,
 } from './core/types';
 
 // ============================================================================

--- a/src/interfaces/Animation.ts
+++ b/src/interfaces/Animation.ts
@@ -15,6 +15,8 @@ import type {
   CompositeRotation,
   CurvePoint,
   AnimationBlendMode,
+  MorphTargetDelta,
+  AddMorphTargetOptions,
 } from '../core/types';
 
 /** Loop mode for mixer clips */
@@ -107,6 +109,29 @@ export interface Animation {
    * @param meshNames - Optional specific meshes to target
    */
   transitionMorphInfluence(index: number, to: number, durationMs?: number, meshNames?: string[]): TransitionHandle;
+
+  /**
+   * Add or replace a runtime morph target on a mesh.
+   * Returns the morphTargetInfluences index assigned to the target.
+   */
+  addMorphTarget(target: MorphTargetDelta, options?: AddMorphTargetOptions): number;
+
+  /**
+   * Add multiple runtime morph targets and return their assigned indices keyed
+   * by "meshName:name".
+   */
+  addMorphTargets(targets: MorphTargetDelta[], options?: AddMorphTargetOptions): Record<string, number>;
+
+  /**
+   * Ensure a named morph influence slot exists on the mesh.
+   * If the target is missing, a zero-delta morph target is created.
+   */
+  ensureMorphInfluence(meshName: string, morphName: string): number;
+
+  /**
+   * Rebuild runtime morph caches after external geometry or dictionary changes.
+   */
+  refreshMorphTargets(meshNames?: string[]): void;
 
   // ============================================================================
   // VISEME

--- a/src/validation/extractModelData.ts
+++ b/src/validation/extractModelData.ts
@@ -139,8 +139,10 @@ function extractMorphs(meshes: THREE.Mesh[]): MorphInfo[] {
     const geo = mesh.geometry;
     if (!geo.morphAttributes) continue;
 
-    // Get morph target dictionary if available
-    const dict = (geo as any).morphTargetDictionary as Record<string, number> | undefined;
+    // GLTFLoader stores the dictionary on Mesh; runtime-authored targets also
+    // mirror it onto geometry for tooling that reads there.
+    const dict = mesh.morphTargetDictionary ||
+      ((geo as any).morphTargetDictionary as Record<string, number> | undefined);
 
     if (dict) {
       for (const [name, index] of Object.entries(dict)) {


### PR DESCRIPTION
## Summary

- Adds public runtime morph authoring APIs: `addMorphTarget`, `addMorphTargets`, `ensureMorphInfluence`, and `refreshMorphTargets`.
- Registers or replaces Three.js morph attributes, updates dictionaries/influences, refreshes Loom3 morph caches, and reapplies active AU/viseme state after mutation.
- Supports static meshes receiving their first morph target and uses BufferGeometry replacement by default for post-render-safe mutation.
- Updates model analysis to read `mesh.morphTargetDictionary`, exports new types, and documents runtime morph target authoring.

Closes #121.

## Validation

- `npm test -- --run src/engines/three/Loom3.morphAuthoring.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`