### PR TITLE
[codex] Restore baked additive safety

### DIFF
--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -16,6 +16,7 @@ import { BakedAnimationController, type BakedAnimationHost } from './AnimationTh
 function makeHost(options: { includeHeadBone?: boolean; includeCamera?: boolean } = {}): {
   controller: BakedAnimationController;
   model: Object3D;
+  mesh: Mesh;
   head: Object3D | null;
   camera: Object3D | null;
 } {
@@ -70,7 +71,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeCamera?: boolean 
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), model, head, camera };
+  return { controller: new BakedAnimationController(host), model, mesh, head, camera };
 }
 
 function makeTransformClip(model: Object3D, name: string): AnimationClip {
@@ -82,6 +83,12 @@ function makeTransformClip(model: Object3D, name: string): AnimationClip {
 function makeMorphClip(name: string): AnimationClip {
   return new AnimationClip(name, 1, [
     new NumberKeyframeTrack('FaceMesh.morphTargetInfluences[0]', [0, 1], [0, 1]),
+  ]);
+}
+
+function makeMorphPoseClip(name: string, start: number, end: number): AnimationClip {
+  return new AnimationClip(name, 1, [
+    new NumberKeyframeTrack('FaceMesh.morphTargetInfluences[0]', [0, 1], [start, end]),
   ]);
 }
 
@@ -200,6 +207,28 @@ describe('BakedAnimationController playback state normalization', () => {
     controller.seekAnimation('HeadPose', 1);
     const expectedDelta = new Quaternion().setFromAxisAngle(new Vector3(1, 0, 0), 0.3);
     expect(head!.quaternion.angleTo(expectedDelta)).toBeLessThan(1e-5);
+  });
+
+  it('lets regular clip-backed snippets play over active baked additive face tracks', () => {
+    const { controller, mesh } = makeHost();
+    controller.loadAnimationClips([makeMorphPoseClip('IdleSmile', 0, 0.4)]);
+
+    const bakedHandle = controller.playAnimation('IdleSmile', { blendMode: 'additive', loopMode: 'once' });
+    expect(bakedHandle).toBeTruthy();
+    controller.seekAnimation('IdleSmile', 1);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.4, 5);
+    controller.seekAnimation('IdleSmile', 0);
+
+    const clipHandle = controller.playClip(makeMorphPoseClip('ExpressionOverride', 0, 0.9), {
+      source: 'snippet',
+      loopMode: 'once',
+    });
+    expect(clipHandle).toBeTruthy();
+    controller.update(0.5);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.45, 5);
+
+    controller.update(0.5);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.9, 5);
   });
 
   it('switches baked face channels to delta clips when additive is toggled after playback starts', () => {

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -6,7 +6,9 @@ import {
   MeshBasicMaterial,
   NumberKeyframeTrack,
   Object3D,
+  Quaternion,
   QuaternionKeyframeTrack,
+  Vector3,
 } from 'three';
 import type { Profile } from '../../mappings/types';
 import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
@@ -91,6 +93,17 @@ function makeMixedClip(model: Object3D, head: Object3D, name: string): Animation
   ]);
 }
 
+function makeOffsetHeadClip(head: Object3D, name: string): AnimationClip {
+  const start = new Quaternion().setFromAxisAngle(new Vector3(1, 0, 0), 0.6);
+  const end = new Quaternion().setFromAxisAngle(new Vector3(1, 0, 0), 0.9);
+  return new AnimationClip(name, 1, [
+    new QuaternionKeyframeTrack(`${head.uuid}.quaternion`, [0, 1], [
+      ...start.toArray(),
+      ...end.toArray(),
+    ]),
+  ]);
+}
+
 function makeSceneClip(camera: Object3D, name: string): AnimationClip {
   return new AnimationClip(name, 1, [
     new NumberKeyframeTrack(`${camera.uuid}.position[x]`, [0, 1], [0, 1]),
@@ -171,6 +184,42 @@ describe('BakedAnimationController playback state normalization', () => {
         { channel: 'body', trackCount: 1, playable: true, blendMode: 'replace' },
       ],
     });
+  });
+
+  it('converts additive baked face bone tracks to deltas before playback', () => {
+    const { controller, head } = makeHost({ includeHeadBone: true });
+    expect(head).toBeTruthy();
+    controller.loadAnimationClips([makeOffsetHeadClip(head!, 'HeadPose')]);
+
+    const handle = controller.playAnimation('HeadPose', { blendMode: 'additive' });
+
+    expect(handle).toBeTruthy();
+    controller.seekAnimation('HeadPose', 0);
+    expect(head!.quaternion.angleTo(new Quaternion())).toBeLessThan(1e-5);
+
+    controller.seekAnimation('HeadPose', 1);
+    const expectedDelta = new Quaternion().setFromAxisAngle(new Vector3(1, 0, 0), 0.3);
+    expect(head!.quaternion.angleTo(expectedDelta)).toBeLessThan(1e-5);
+  });
+
+  it('switches baked face channels to delta clips when additive is toggled after playback starts', () => {
+    const { controller, head } = makeHost({ includeHeadBone: true });
+    expect(head).toBeTruthy();
+    controller.loadAnimationClips([makeOffsetHeadClip(head!, 'HeadPose')]);
+
+    controller.playAnimation('HeadPose', { blendMode: 'replace' });
+    controller.seekAnimation('HeadPose', 0.5);
+    controller.setAnimationBlendMode('HeadPose', 'additive');
+    controller.seekAnimation('HeadPose', 0);
+
+    expect(controller.getAnimationState('HeadPose')).toMatchObject({
+      requestedBlendMode: 'additive',
+      blendMode: 'additive',
+      channels: [
+        { channel: 'face', trackCount: 1, playable: true, blendMode: 'additive' },
+      ],
+    });
+    expect(head!.quaternion.angleTo(new Quaternion())).toBeLessThan(1e-5);
   });
 
   it('surfaces scene-only partitions without creating a Loom3-playable action', () => {

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -262,8 +262,11 @@ const ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX = '__loom3_additive_delta';
 
 export class BakedAnimationController {
   private host: BakedAnimationHost;
+  // Clip-backed snippets need a later mixer pass so they can override baked additive tracks.
   private animationMixer: AnimationMixer | null = null;
+  private clipAnimationMixer: AnimationMixer | null = null;
   private mixerFinishedListenerAttached = false;
+  private clipMixerFinishedListenerAttached = false;
   private animationClips: AnimationClip[] = [];
   private bakedSourceClips = new Map<string, PartitionedBakedClip>();
   private bakedRuntimeActions = new Map<string, AnimationAction>();
@@ -307,20 +310,26 @@ export class BakedAnimationController {
     delete action.__actionId;
   }
 
-  private uncacheClip(clip?: AnimationClip | null): void {
-    if (!clip || !this.animationMixer) return;
+  private uncacheClip(
+    clip?: AnimationClip | null,
+    mixer: AnimationMixer | null = this.animationMixer
+  ): void {
+    if (!clip || !mixer) return;
     try {
-      this.animationMixer.uncacheClip(clip);
+      mixer.uncacheClip(clip);
     } catch {}
   }
 
-  private uncacheAction(action?: AnimationAction | null): void {
-    if (!action || !this.animationMixer) return;
+  private uncacheAction(
+    action?: AnimationAction | null,
+    mixer: AnimationMixer | null = this.animationMixer
+  ): void {
+    if (!action || !mixer) return;
     try {
       const clip = action.getClip();
       if (clip) {
-        this.animationMixer.uncacheAction(clip);
-        this.animationMixer.uncacheClip(clip);
+        mixer.uncacheAction(clip);
+        mixer.uncacheClip(clip);
       }
     } catch {}
   }
@@ -1006,14 +1015,15 @@ export class BakedAnimationController {
 
   update(dtSeconds: number): void {
     if (this.animationMixer) {
+      this.animationMixer.update(dtSeconds);
+    }
+
+    if (this.clipAnimationMixer) {
       const snapshots = Array.from(this.clipMonitors.values()).map((monitor) => ({
         actionId: monitor.actionId,
         previousTime: monitor.action.time,
       }));
-      this.animationMixer.update(dtSeconds);
-      if (this.hasActiveAdditivePlayback()) {
-        this.host.reapplyProceduralState?.();
-      }
+      this.clipAnimationMixer.update(dtSeconds);
       for (const { actionId, previousTime } of snapshots) {
         const monitor = this.clipMonitors.get(actionId);
         if (!monitor) continue;
@@ -1032,6 +1042,10 @@ export class BakedAnimationController {
         }
       }
     }
+
+    if (this.hasActiveAdditivePlayback()) {
+      this.host.reapplyProceduralState?.();
+    }
   }
 
   dispose(): void {
@@ -1041,6 +1055,12 @@ export class BakedAnimationController {
       this.animationMixer.stopAllAction();
       this.animationMixer = null;
     }
+    if (this.clipAnimationMixer) {
+      this.clipAnimationMixer.stopAllAction();
+      this.clipAnimationMixer = null;
+    }
+    this.mixerFinishedListenerAttached = false;
+    this.clipMixerFinishedListenerAttached = false;
     this.animationClips = [];
     this.bakedSourceClips.clear();
     this.bakedRuntimeActions.clear();
@@ -1218,12 +1238,12 @@ export class BakedAnimationController {
       const actionId = this.getActionId(action);
       const isBaked = (this.clipSources.get(clipName) ?? 'baked') === 'baked';
       action.stop();
-      if (!isBaked && this.animationMixer) {
+      if (!isBaked && this.clipAnimationMixer) {
         try {
           const clip = action.getClip();
           if (clip) {
-            this.animationMixer.uncacheAction(clip);
-            this.animationMixer.uncacheClip(clip);
+            this.clipAnimationMixer.uncacheAction(clip);
+            this.clipAnimationMixer.uncacheClip(clip);
           }
         } catch {}
       }
@@ -1241,11 +1261,11 @@ export class BakedAnimationController {
       const actionId = this.getActionId(clipAction);
       try {
         clipAction.stop();
-        if (this.animationMixer) {
+        if (this.clipAnimationMixer) {
           const clip = clipAction.getClip();
           if (clip) {
-            this.animationMixer.uncacheAction(clip);
-            this.animationMixer.uncacheClip(clip);
+            this.clipAnimationMixer.uncacheAction(clip);
+            this.clipAnimationMixer.uncacheClip(clip);
           }
         }
       } catch {}
@@ -1517,6 +1537,7 @@ export class BakedAnimationController {
       }
       try {
         this.animationMixer?.update(0);
+        this.clipAnimationMixer?.update(0);
         if (state.blendMode === 'additive') {
           this.host.reapplyProceduralState?.();
         }
@@ -1529,7 +1550,7 @@ export class BakedAnimationController {
     const duration = action.getClip().duration;
     action.time = Math.max(0, Math.min(duration, Number.isFinite(time) ? time : 0));
     try {
-      this.animationMixer?.update(0);
+      this.clipAnimationMixer?.update(0);
       const state = this.playbackState.get(clipName);
       if (state?.blendMode === 'additive') {
         this.host.reapplyProceduralState?.();
@@ -1540,6 +1561,9 @@ export class BakedAnimationController {
   setAnimationTimeScale(timeScale: number): void {
     if (this.animationMixer) {
       this.animationMixer.timeScale = timeScale;
+    }
+    if (this.clipAnimationMixer) {
+      this.clipAnimationMixer.timeScale = timeScale;
     }
   }
 
@@ -1977,9 +2001,9 @@ export class BakedAnimationController {
   }
 
   playClip(clip: AnimationClip, options?: ClipOptions): ClipHandle | null {
-    this.ensureMixer();
+    const mixer = this.ensureClipMixer();
 
-    if (!this.animationMixer) {
+    if (!mixer) {
       console.warn('[Loom3] playClip: No model loaded, cannot create mixer');
       return null;
     }
@@ -1999,7 +2023,7 @@ export class BakedAnimationController {
       actionId = this.setActionId(action, clip.name);
     }
     if (!action) {
-      action = this.animationMixer.clipAction(clip);
+      action = mixer.clipAction(clip);
       actionId = this.setActionId(action, clip.name);
     }
 
@@ -2069,10 +2093,8 @@ export class BakedAnimationController {
       stop: () => {
         action.stop();
         // Fully remove action from mixer to prevent accumulation and weight blending issues
-        if (this.animationMixer) {
-          try { this.animationMixer.uncacheAction(clip); } catch {}
-          try { this.animationMixer.uncacheClip(clip); } catch {}
-        }
+        try { mixer.uncacheAction(clip); } catch {}
+        try { mixer.uncacheClip(clip); } catch {}
         this.clipActions.delete(clip.name);
         this.animationActions.delete(clip.name);
         this.animationFinishedCallbacks.delete(clip.name);
@@ -2117,7 +2139,7 @@ export class BakedAnimationController {
       setTime: (t: number) => {
         const clamped = Math.max(0, Math.min(clip.duration, t));
         action.time = clamped;
-        try { this.animationMixer?.update(0); } catch {}
+        try { mixer.update(0); } catch {}
         this.syncClipMonitorTime(monitor, clamped, true);
       },
 
@@ -2163,7 +2185,7 @@ export class BakedAnimationController {
   }
 
   cleanupSnippet(name: string) {
-    if (!this.animationMixer || !this.host.getModel()) return;
+    if (!this.host.getModel()) return;
     for (const [clipName, action] of Array.from(this.clipActions.entries())) {
       if (clipName === name || clipName.startsWith(`${name}_`)) {
         const actionId = this.getActionId(action);
@@ -2171,9 +2193,9 @@ export class BakedAnimationController {
           action.stop();
           // Fully remove action from mixer to prevent accumulation
           const clip = action.getClip();
-          if (clip) {
-            this.animationMixer.uncacheAction(clip);
-            this.animationMixer.uncacheClip(clip);
+          if (clip && this.clipAnimationMixer) {
+            this.clipAnimationMixer.uncacheAction(clip);
+            this.clipAnimationMixer.uncacheClip(clip);
           }
         } catch {}
         this.clipActions.delete(clipName);
@@ -2202,7 +2224,10 @@ export class BakedAnimationController {
       clipActions: Array.from(this.clipActions.entries()).map(([k, a]) => ({ name: k, actionId: this.getActionId(a) })),
       animationActions: Array.from(this.animationActions.entries()).map(([k, a]) => ({ name: k, actionId: this.getActionId(a) })),
       clipHandles: Array.from(this.clipHandles.entries()).map(([k, h]) => ({ name: k, actionId: h.actionId })),
-      mixerActions: (this.animationMixer?._actions || []).map((a: AnimationAction) => ({ name: a?.getClip?.()?.name || '', actionId: this.getActionId(a) })),
+      mixerActions: [
+        ...(this.animationMixer?._actions || []),
+        ...(this.clipAnimationMixer?._actions || []),
+      ].map((a: AnimationAction) => ({ name: a?.getClip?.()?.name || '', actionId: this.getActionId(a) })),
     });
 
     console.log('[Loom3] updateClipParams start', debugSnapshot());
@@ -2353,35 +2378,53 @@ export class BakedAnimationController {
     }
 
     if (this.animationMixer && !this.mixerFinishedListenerAttached) {
-      this.animationMixer.addEventListener('finished', (event: any) => {
-        const action = event.action as AnimationAction;
-        const actionId = this.getActionId(action);
-        if (actionId) {
-          const monitor = this.clipMonitors.get(actionId);
-          if (monitor) {
-            monitor.finishedPending = true;
-            return;
-          }
-        }
-        const clip = action.getClip();
-        const bakedRuntime = this.bakedRuntimeClipToSource.get(clip.name);
-        if (bakedRuntime) {
-          const group = this.bakedActionGroups.get(bakedRuntime.sourceClipName);
-          if (group && group.pendingFinishedChannels.delete(bakedRuntime.channel) && group.pendingFinishedChannels.size === 0) {
-            group.resolveFinished();
-          }
-          return;
-        }
-        const callback = this.animationFinishedCallbacks.get(clip.name);
-        if (callback) {
-          callback();
-          this.animationFinishedCallbacks.delete(clip.name);
-        }
-      });
+      this.animationMixer.addEventListener('finished', (event: any) => this.handleMixerFinished(event));
       this.mixerFinishedListenerAttached = true;
     }
 
     return this.animationMixer;
+  }
+
+  private ensureClipMixer(): AnimationMixer | null {
+    const model = this.host.getModel();
+    if (!model) return null;
+
+    if (!this.clipAnimationMixer) {
+      this.clipAnimationMixer = new AnimationMixer(model);
+    }
+
+    if (this.clipAnimationMixer && !this.clipMixerFinishedListenerAttached) {
+      this.clipAnimationMixer.addEventListener('finished', (event: any) => this.handleMixerFinished(event));
+      this.clipMixerFinishedListenerAttached = true;
+    }
+
+    return this.clipAnimationMixer;
+  }
+
+  private handleMixerFinished(event: any): void {
+    const action = event.action as AnimationAction;
+    const actionId = this.getActionId(action);
+    if (actionId) {
+      const monitor = this.clipMonitors.get(actionId);
+      if (monitor) {
+        monitor.finishedPending = true;
+        return;
+      }
+    }
+    const clip = action.getClip();
+    const bakedRuntime = this.bakedRuntimeClipToSource.get(clip.name);
+    if (bakedRuntime) {
+      const group = this.bakedActionGroups.get(bakedRuntime.sourceClipName);
+      if (group && group.pendingFinishedChannels.delete(bakedRuntime.channel) && group.pendingFinishedChannels.size === 0) {
+        group.resolveFinished();
+      }
+      return;
+    }
+    const callback = this.animationFinishedCallbacks.get(clip.name);
+    if (callback) {
+      callback();
+      this.animationFinishedCallbacks.delete(clip.name);
+    }
   }
 
   private createAnimationHandle(

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -8,7 +8,9 @@ import {
   AnimationMixer,
   AnimationAction,
   AnimationClip,
+  AnimationUtils,
   NumberKeyframeTrack,
+  PropertyBinding,
   QuaternionKeyframeTrack,
   AdditiveAnimationBlendMode,
   LoopRepeat,
@@ -17,8 +19,9 @@ import {
   NormalAnimationBlendMode,
   Quaternion,
   Vector3,
+  VectorKeyframeTrack,
 } from 'three';
-import type { Mesh, Object3D } from 'three';
+import type { KeyframeTrack, Mesh, Object3D } from 'three';
 import type {
   TransitionHandle,
   AnimationPlayOptions,
@@ -199,6 +202,7 @@ export interface BakedAnimationHost {
   computeSideValues: (base: number, balance?: number) => { left: number; right: number };
   getAUMixWeight: (auId: number) => number;
   isMixedAU: (auId: number) => boolean;
+  reapplyProceduralState?: () => void;
 }
 
 // Lightweight unique id for mixer actions/handles
@@ -254,6 +258,8 @@ type BakedActionGroup = {
   resolveFinished: () => void;
 };
 
+const ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX = '__loom3_additive_delta';
+
 export class BakedAnimationController {
   private host: BakedAnimationHost;
   private animationMixer: AnimationMixer | null = null;
@@ -261,6 +267,7 @@ export class BakedAnimationController {
   private animationClips: AnimationClip[] = [];
   private bakedSourceClips = new Map<string, PartitionedBakedClip>();
   private bakedRuntimeActions = new Map<string, AnimationAction>();
+  private bakedAdditiveRuntimeClips = new Map<string, AnimationClip>();
   private bakedActionGroups = new Map<string, BakedActionGroup>();
   private bakedRuntimeClipToSource = new Map<string, { sourceClipName: string; channel: BakedClipChannel }>();
   private animationActions = new Map<string, AnimationAction>();
@@ -288,6 +295,213 @@ export class BakedAnimationController {
     this.actionIdToClip.set(actionId, clipName);
     action.__actionId = actionId;
     return actionId;
+  }
+
+  private clearActionId(action?: AnimationAction | null): void {
+    if (!action) return;
+    const actionId = this.getActionId(action);
+    if (actionId) {
+      this.actionIdToClip.delete(actionId);
+    }
+    this.actionIds.delete(action);
+    delete action.__actionId;
+  }
+
+  private uncacheClip(clip?: AnimationClip | null): void {
+    if (!clip || !this.animationMixer) return;
+    try {
+      this.animationMixer.uncacheClip(clip);
+    } catch {}
+  }
+
+  private uncacheAction(action?: AnimationAction | null): void {
+    if (!action || !this.animationMixer) return;
+    try {
+      const clip = action.getClip();
+      if (clip) {
+        this.animationMixer.uncacheAction(clip);
+        this.animationMixer.uncacheClip(clip);
+      }
+    } catch {}
+  }
+
+  private releaseBakedRuntimeAction(runtimeClipName: string): void {
+    const action = this.bakedRuntimeActions.get(runtimeClipName);
+    if (!action) return;
+    try {
+      action.stop();
+    } catch {}
+    this.uncacheAction(action);
+    this.clearActionId(action);
+    this.bakedRuntimeActions.delete(runtimeClipName);
+  }
+
+  private clearBakedAdditiveRuntimeClip(runtimeClipName: string): void {
+    const clip = this.bakedAdditiveRuntimeClips.get(runtimeClipName);
+    if (!clip) return;
+    this.uncacheClip(clip);
+    this.bakedAdditiveRuntimeClips.delete(runtimeClipName);
+  }
+
+  private clearAllBakedAdditiveRuntimeClips(): void {
+    for (const runtimeClipName of Array.from(this.bakedAdditiveRuntimeClips.keys())) {
+      this.clearBakedAdditiveRuntimeClip(runtimeClipName);
+    }
+  }
+
+  private resolveTrackTarget(
+    model: Object3D,
+    parsed: ReturnType<typeof PropertyBinding.parseTrackName>
+  ): Object3D | null {
+    const targetKey = parsed.objectName === 'bones' && parsed.objectIndex
+      ? parsed.objectIndex
+      : parsed.nodeName;
+    if (!targetKey) {
+      return null;
+    }
+    return model.getObjectByProperty('uuid', targetKey)
+      ?? PropertyBinding.findNode(model, targetKey)
+      ?? null;
+  }
+
+  private getMorphTrackBaseValue(
+    target: Object3D | null,
+    propertyIndex: string | number | undefined
+  ): number {
+    if (!target) {
+      return 0;
+    }
+
+    const meshTarget = target as Mesh & {
+      morphTargetInfluences?: number[];
+      morphTargetDictionary?: Record<string, number>;
+    };
+    const influences = meshTarget.morphTargetInfluences;
+    if (!influences) {
+      return 0;
+    }
+
+    let morphIndex: number | undefined;
+    if (typeof propertyIndex === 'number' && Number.isInteger(propertyIndex)) {
+      morphIndex = propertyIndex;
+    } else if (typeof propertyIndex === 'string') {
+      if (/^\d+$/.test(propertyIndex)) {
+        morphIndex = Number(propertyIndex);
+      } else {
+        morphIndex = meshTarget.morphTargetDictionary?.[propertyIndex];
+      }
+    }
+
+    if (morphIndex === undefined) {
+      return 0;
+    }
+
+    return influences[morphIndex] ?? 0;
+  }
+
+  private canCreateFirstFrameReferenceTrack(track: KeyframeTrack): boolean {
+    const valueSize = track.getValueSize();
+    if (!Number.isFinite(valueSize) || valueSize <= 0 || track.values.length < valueSize) {
+      return false;
+    }
+
+    return track.ValueTypeName === 'number'
+      || track.ValueTypeName === 'quaternion'
+      || track.ValueTypeName === 'vector';
+  }
+
+  private createFirstFrameReferenceTrack(track: KeyframeTrack): KeyframeTrack | null {
+    const valueSize = track.getValueSize();
+    if (!this.canCreateFirstFrameReferenceTrack(track)) {
+      return null;
+    }
+
+    const values = Array.from(track.values.slice(0, valueSize));
+    if (track.ValueTypeName === 'number') {
+      return new NumberKeyframeTrack(track.name, [0], values);
+    }
+    if (track.ValueTypeName === 'quaternion') {
+      return new QuaternionKeyframeTrack(track.name, [0], values);
+    }
+    if (track.ValueTypeName === 'vector') {
+      return new VectorKeyframeTrack(track.name, [0], values);
+    }
+    return null;
+  }
+
+  private createAdditiveReferenceTrack(
+    track: KeyframeTrack,
+    model: Object3D
+  ): KeyframeTrack | null {
+    const trackName = typeof track?.name === 'string' ? track.name : '';
+    if (!trackName) {
+      return null;
+    }
+
+    let parsed: ReturnType<typeof PropertyBinding.parseTrackName>;
+    try {
+      parsed = PropertyBinding.parseTrackName(trackName);
+    } catch {
+      return null;
+    }
+
+    const target = this.resolveTrackTarget(model, parsed);
+    if (parsed.propertyName === 'morphTargetInfluences') {
+      return new NumberKeyframeTrack(
+        track.name,
+        [0],
+        [this.getMorphTrackBaseValue(target, parsed.propertyIndex)]
+      );
+    }
+
+    return this.createFirstFrameReferenceTrack(track);
+  }
+
+  private createAdditiveRuntimeClip(runtimeClip: AnimationClip): AnimationClip | null {
+    const model = this.host.getModel();
+    if (!model) {
+      return null;
+    }
+
+    const additiveTracks: KeyframeTrack[] = [];
+    const referenceTracks: KeyframeTrack[] = [];
+    for (const track of runtimeClip.tracks) {
+      const referenceTrack = this.createAdditiveReferenceTrack(track, model);
+      if (!referenceTrack) {
+        continue;
+      }
+      additiveTracks.push(track.clone());
+      referenceTracks.push(referenceTrack);
+    }
+
+    const additiveClip = new AnimationClip(
+      `${runtimeClip.name}${ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX}`,
+      runtimeClip.duration,
+      additiveTracks
+    );
+    if (additiveTracks.length > 0) {
+      const referenceClip = new AnimationClip(
+        `${runtimeClip.name}${ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX}_reference`,
+        0,
+        referenceTracks
+      );
+      AnimationUtils.makeClipAdditive(additiveClip, 0, referenceClip);
+    }
+    return additiveClip;
+  }
+
+  private getOrCreateBakedAdditiveRuntimeClip(runtimeClip: AnimationClip): AnimationClip | null {
+    const cached = this.bakedAdditiveRuntimeClips.get(runtimeClip.name);
+    if (cached) {
+      return cached;
+    }
+
+    const additiveClip = this.createAdditiveRuntimeClip(runtimeClip);
+    if (!additiveClip) {
+      return null;
+    }
+    this.bakedAdditiveRuntimeClips.set(runtimeClip.name, additiveClip);
+    return additiveClip;
   }
 
   private setClipEventMetadata(clip: AnimationClip, metadata: ClipEventMetadata) {
@@ -652,7 +866,8 @@ export class BakedAnimationController {
 
   private getOrCreateBakedRuntimeAction(
     sourceClipName: string,
-    channel: BakedClipChannel
+    channel: BakedClipChannel,
+    blendMode: AnimationBlendMode = 'replace'
   ): AnimationAction | null {
     const bakedClip = this.getBakedSourceClip(sourceClipName);
     const runtimeClip = bakedClip?.runtimeClips.find((entry) => entry.channel === channel)?.clip;
@@ -660,8 +875,15 @@ export class BakedAnimationController {
       return null;
     }
 
+    const desiredClip = blendMode === 'additive'
+      ? this.getOrCreateBakedAdditiveRuntimeClip(runtimeClip)
+      : runtimeClip;
+    if (!desiredClip) {
+      return null;
+    }
+
     const existing = this.bakedRuntimeActions.get(runtimeClip.name);
-    if (existing) {
+    if (existing?.getClip() === desiredClip) {
       return existing;
     }
 
@@ -670,7 +892,11 @@ export class BakedAnimationController {
       return null;
     }
 
-    const action = this.animationMixer.clipAction(runtimeClip);
+    if (existing) {
+      this.releaseBakedRuntimeAction(runtimeClip.name);
+    }
+
+    const action = this.animationMixer.clipAction(desiredClip);
     this.bakedRuntimeActions.set(runtimeClip.name, action);
     return action;
   }
@@ -694,7 +920,15 @@ export class BakedAnimationController {
 
     const channelActions = new Map<BakedClipChannel, AnimationAction>();
     for (const runtimeClip of bakedClip.runtimeClips) {
-      const action = this.getOrCreateBakedRuntimeAction(clipName, runtimeClip.channel);
+      const channelBlendMode = resolveBakedChannelBlendMode(
+        runtimeClip.channel,
+        playbackState.requestedBlendMode
+      ) ?? 'replace';
+      const action = this.getOrCreateBakedRuntimeAction(
+        clipName,
+        runtimeClip.channel,
+        channelBlendMode
+      );
       if (action) {
         channelActions.set(runtimeClip.channel, action);
       }
@@ -744,6 +978,32 @@ export class BakedAnimationController {
     return getMeshNamesForVisemeProfile(config);
   }
 
+  private hasActiveAdditivePlayback(): boolean {
+    for (const [clipName, group] of this.bakedActionGroups) {
+      const state = this.playbackState.get(clipName);
+      if (state?.blendMode !== 'additive') {
+        continue;
+      }
+      for (const action of group.channelActions.values()) {
+        if (action.isRunning() && !action.paused) {
+          return true;
+        }
+      }
+    }
+
+    for (const [clipName, action] of this.animationActions) {
+      const state = this.playbackState.get(clipName);
+      if (state?.blendMode !== 'additive') {
+        continue;
+      }
+      if (action.isRunning() && !action.paused) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   update(dtSeconds: number): void {
     if (this.animationMixer) {
       const snapshots = Array.from(this.clipMonitors.values()).map((monitor) => ({
@@ -751,6 +1011,9 @@ export class BakedAnimationController {
         previousTime: monitor.action.time,
       }));
       this.animationMixer.update(dtSeconds);
+      if (this.hasActiveAdditivePlayback()) {
+        this.host.reapplyProceduralState?.();
+      }
       for (const { actionId, previousTime } of snapshots) {
         const monitor = this.clipMonitors.get(actionId);
         if (!monitor) continue;
@@ -773,6 +1036,7 @@ export class BakedAnimationController {
 
   dispose(): void {
     this.stopAllAnimations();
+    this.clearAllBakedAdditiveRuntimeClips();
     if (this.animationMixer) {
       this.animationMixer.stopAllAction();
       this.animationMixer = null;
@@ -780,6 +1044,7 @@ export class BakedAnimationController {
     this.animationClips = [];
     this.bakedSourceClips.clear();
     this.bakedRuntimeActions.clear();
+    this.bakedAdditiveRuntimeClips.clear();
     this.bakedActionGroups.clear();
     this.bakedRuntimeClipToSource.clear();
     this.animationActions.clear();
@@ -804,6 +1069,8 @@ export class BakedAnimationController {
     if (this.animationMixer) {
       for (const bakedClip of this.bakedSourceClips.values()) {
         for (const runtimeClip of bakedClip.runtimeClips) {
+          this.releaseBakedRuntimeAction(runtimeClip.clip.name);
+          this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
           try {
             this.animationMixer.uncacheAction(runtimeClip.clip);
           } catch {}
@@ -813,6 +1080,7 @@ export class BakedAnimationController {
         }
       }
     }
+    this.clearAllBakedAdditiveRuntimeClips();
 
     for (const clipName of this.bakedSourceClips.keys()) {
       this.playbackState.delete(clipName);
@@ -863,13 +1131,14 @@ export class BakedAnimationController {
     if (this.animationMixer) {
       for (const runtimeClip of bakedClip.runtimeClips) {
         const action = this.bakedRuntimeActions.get(runtimeClip.clip.name);
+        this.releaseBakedRuntimeAction(runtimeClip.clip.name);
+        this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
         try {
           this.animationMixer.uncacheAction(runtimeClip.clip);
         } catch {}
         try {
           this.animationMixer.uncacheClip(runtimeClip.clip);
         } catch {}
-        this.bakedRuntimeActions.delete(runtimeClip.clip.name);
         this.bakedRuntimeClipToSource.delete(runtimeClip.clip.name);
         const actionId = this.getActionId(action);
         if (actionId && action) {
@@ -877,6 +1146,10 @@ export class BakedAnimationController {
           this.actionIds.delete(action);
         }
       }
+    }
+    for (const runtimeClip of bakedClip.runtimeClips) {
+      this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
+      this.bakedRuntimeActions.delete(runtimeClip.clip.name);
     }
 
     this.animationClips = this.animationClips.filter((entry) => entry.name !== clipName);
@@ -1199,8 +1472,24 @@ export class BakedAnimationController {
       next.blendMode = this.getBakedAggregateBlendMode(clipName, next);
       const bakedGroup = this.bakedActionGroups.get(clipName);
       if (bakedGroup) {
-        for (const [channel, action] of bakedGroup.channelActions) {
+        for (const [channel, currentAction] of Array.from(bakedGroup.channelActions)) {
+          const channelBlendMode = resolveBakedChannelBlendMode(channel, next.requestedBlendMode) ?? 'replace';
+          const previousTime = currentAction.time;
+          const wasActive = currentAction.isRunning() || currentAction.paused;
+          const wasPaused = currentAction.paused;
+          const action = this.getOrCreateBakedRuntimeAction(clipName, channel, channelBlendMode);
+          if (!action) {
+            bakedGroup.channelActions.delete(channel);
+            continue;
+          }
+
           this.applyPlaybackStateToBakedAction(action, next, channel);
+          action.time = Math.max(0, Math.min(action.getClip().duration, previousTime));
+          if (action !== currentAction && wasActive) {
+            action.play();
+          }
+          action.paused = wasPaused;
+          bakedGroup.channelActions.set(channel, action);
         }
       }
       this.setPlaybackState(clipName, next);
@@ -1217,6 +1506,10 @@ export class BakedAnimationController {
   seekAnimation(clipName: string, time: number): void {
     const bakedGroup = this.bakedActionGroups.get(clipName);
     if (bakedGroup) {
+      const state = this.getPlaybackStateSnapshot(clipName, {
+        loop: true,
+        source: this.clipSources.get(clipName) ?? 'baked',
+      });
       const duration = this.getBakedSourceClip(clipName)?.sourceClip.duration ?? 0;
       const clamped = Math.max(0, Math.min(duration, Number.isFinite(time) ? time : 0));
       for (const action of bakedGroup.channelActions.values()) {
@@ -1224,6 +1517,9 @@ export class BakedAnimationController {
       }
       try {
         this.animationMixer?.update(0);
+        if (state.blendMode === 'additive') {
+          this.host.reapplyProceduralState?.();
+        }
       } catch {}
       return;
     }
@@ -1234,6 +1530,10 @@ export class BakedAnimationController {
     action.time = Math.max(0, Math.min(duration, Number.isFinite(time) ? time : 0));
     try {
       this.animationMixer?.update(0);
+      const state = this.playbackState.get(clipName);
+      if (state?.blendMode === 'additive') {
+        this.host.reapplyProceduralState?.();
+      }
     } catch {}
   }
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -205,6 +205,7 @@ export class Loom3 implements LoomLarge {
       computeSideValues: (base, balance) => this.computeSideValues(base, balance),
       getAUMixWeight: (auId) => this.getAUMixWeight(auId),
       isMixedAU: (auId) => this.isMixedAU(auId),
+      reapplyProceduralState: () => this.reapplyProceduralStateAfterBakedUpdate(),
     });
 
     this.hairPhysics = new HairPhysicsController({
@@ -1119,6 +1120,36 @@ export class Loom3 implements LoomLarge {
       this.flushPendingComposites();
       this.model.updateMatrixWorld(true);
     }
+  }
+
+  private reapplyProceduralStateAfterBakedUpdate(): void {
+    if (!this.model) {
+      return;
+    }
+
+    let hasActiveOverrides = false;
+
+    for (const [auIdStr, value] of Object.entries(this.auValues)) {
+      if (value <= 0) continue;
+      const auId = Number(auIdStr);
+      if (Number.isNaN(auId)) continue;
+      hasActiveOverrides = true;
+      this.setAU(auId, value, this.auBalances[auId]);
+    }
+
+    for (let visemeIndex = 0; visemeIndex < this.visemeValues.length; visemeIndex += 1) {
+      const value = this.visemeValues[visemeIndex] ?? 0;
+      if (value <= 0) continue;
+      hasActiveOverrides = true;
+      this.setViseme(visemeIndex, value, this.visemeJawScales[visemeIndex] ?? 1);
+    }
+
+    if (!hasActiveOverrides) {
+      return;
+    }
+
+    this.flushPendingComposites();
+    this.model.updateMatrixWorld(true);
   }
 
   // ============================================================================


### PR DESCRIPTION
## Summary

Restores the baked additive animation safety behavior that was lost from the current Loom3 mainline after baked clip partitioning landed, and fixes the follow-up regression where regular procedural clips could not reliably play over an active baked additive clip.

- Creates additive delta runtime clips for baked face-channel playback instead of applying Three.js additive mode directly to absolute baked tracks.
- Keeps body-channel baked tracks on replace blending and scene tracks non-playable, preserving the current partitioned-channel contract.
- Restores the procedural AU/viseme reapply hook after additive mixer updates so additive baked playback layers over current runtime controls.
- Separates baked animation actions from regular clip/snippet actions into two Three.js mixers, then evaluates the regular clip mixer after the baked mixer so clip-backed procedural snippets can override baked additive face tracks.
- Adds regression tests for direct additive face-bone playback, toggling a baked clip from replace to additive after playback starts, and regular snippet playback over an active baked additive face track.

## Root Cause

The earlier baked additive fix lived on `codex/fix-baked-additive-jaw`, but current `main` and the published Loom3 package line contain the later baked clip partitioning work without that additive-safe conversion. As a result, face/jaw/head quaternion tracks could be routed to an additive face channel while still containing absolute baked transforms.

The follow-up issue was a second blending problem in the same controller: baked actions and regular procedural snippet clips shared a single `AnimationMixer`. In Three.js, an additive action on a property is accumulated on top of a normal/replace action for that same property. That meant an additive baked face pose stayed added after a regular snippet set its own absolute morph/bone value. The reproduced case was a baked additive smile at `0.4` plus a regular snippet expression at `0.9` producing `1.3` instead of letting the snippet own the final `0.9` value.

The fix keeps baked and regular clip actions on separate mixers. Loom3 now updates baked playback first and then updates regular clip-backed snippets, preserving baked additive behavior while making regular procedural clips the later/high-priority pass.

## Validation

- `npm test -- --run src/engines/three/AnimationThree.playbackState.test.ts src/engines/three/bakedClipPartitioning.test.ts`
- `npm test -- --run src/engines/three/AnimationThree.playbackState.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`