### PR TITLE
[codex] Align live viseme runtime with bindings

### DIFF
--- a/src/engines/three/AnimationThree.meshSelection.test.ts
+++ b/src/engines/three/AnimationThree.meshSelection.test.ts
@@ -121,6 +121,44 @@ describe('BakedAnimationController mesh selection', () => {
     expect(trackNames.some((name) => name.includes((faceMesh as any).uuid))).toBe(false);
   });
 
+  it('builds viseme clip tracks from one-to-many weighted bindings', () => {
+    const visemeMesh = makeMorphMesh('VisemeMesh', { Mouth_Aah: 0, Mouth_Wide: 1 });
+
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: [], viseme: ['VisemeMesh'] },
+      visemeKeys: ['Legacy_AA'],
+      visemeSlots: [{ id: 'aa', label: 'AA', order: 0 }],
+      visemeBindings: {
+        aa: {
+          targets: [
+            { morph: 'Mouth_Aah' },
+            { morph: 'Mouth_Wide', weight: 0.5 },
+          ],
+        },
+      },
+      visemeMeshCategory: 'viseme',
+    };
+
+    const host = makeHost(profile, [visemeMesh]);
+    const controller = new BakedAnimationController(host);
+    const clip = controller.snippetToClip(
+      'viseme-bindings',
+      { '0': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] },
+      { snippetCategory: 'visemeSnippet' }
+    );
+
+    expect(clip).toBeTruthy();
+    const trackByName = new Map(clip!.tracks.map((track) => [track.name, track]));
+    const aahTrack = trackByName.get(`${(visemeMesh as any).uuid}.morphTargetInfluences[0]`);
+    const wideTrack = trackByName.get(`${(visemeMesh as any).uuid}.morphTargetInfluences[1]`);
+
+    expect(aahTrack?.values[1]).toBeCloseTo(1);
+    expect(wideTrack?.values[1]).toBeCloseTo(0.5);
+  });
+
   it('does not fall back to face when the explicit viseme mesh category is empty', () => {
     const faceMesh = makeMorphMesh('FaceMesh', { Viseme_AA: 0 });
 

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -44,7 +44,13 @@ import type {
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
 import type { Profile } from '../../mappings/types';
-import { getMeshNamesForAUProfile, getMeshNamesForVisemeProfile } from '../../mappings/visemeSystem';
+import {
+  getMeshNamesForAUProfile,
+  getMeshNamesForVisemeProfile,
+  getProfileVisemeSlots,
+  getVisemeBindingTargets,
+  getVisemeJawAmounts,
+} from '../../mappings/visemeSystem';
 import type { ResolvedBones } from './types';
 import { getSideScale, resolveCurveBalance } from './balanceUtils';
 import {
@@ -1699,13 +1705,14 @@ export class BakedAnimationController {
     const globalBalance = options?.balance ?? 0;
     const balanceMap = options?.balanceMap;
     const meshNames = options?.meshNames;
+    const visemeSlotCount = getProfileVisemeSlots(config).length;
     let maxTime = 0;
 
     const isNumericAU = (id: string) => /^\d+$/.test(id);
     const isVisemeIndex = (id: string) => {
       if (options?.snippetCategory !== 'visemeSnippet') return false;
       const num = Number(id);
-      return !Number.isNaN(num) && num >= 0 && num < config.visemeKeys.length;
+      return !Number.isNaN(num) && num >= 0 && num < visemeSlotCount;
     };
 
     const sampleAt = (arr: Array<{ time: number; intensity: number }>, t: number) => {
@@ -1750,11 +1757,13 @@ export class BakedAnimationController {
 
         if (isVisemeIndex(curveId)) {
           const visemeMeshNames = this.getMeshNamesForViseme(config, meshNames);
-          const visemeKey = config.visemeKeys[auId];
-          if (typeof visemeKey === 'number') {
-            this.addMorphIndexTracks(tracks, visemeKey, keyframes, intensityScale, visemeMeshNames);
-          } else if (visemeKey) {
-            this.addMorphTracks(tracks, visemeKey, keyframes, intensityScale, visemeMeshNames);
+          for (const target of getVisemeBindingTargets(config, auId)) {
+            const effectiveScale = intensityScale * target.weight;
+            if (typeof target.morph === 'number') {
+              this.addMorphIndexTracks(tracks, target.morph, keyframes, effectiveScale, visemeMeshNames);
+            } else if (target.morph) {
+              this.addMorphTracks(tracks, target.morph, keyframes, effectiveScale, visemeMeshNames);
+            }
           }
         } else {
           const auMeshNames = this.getMeshNamesForAU(auId, config, meshNames);
@@ -1803,7 +1812,7 @@ export class BakedAnimationController {
     // This replicates transitionViseme behavior for clip-based playback
     const autoVisemeJaw = options?.autoVisemeJaw !== false; // Default true
     const jawScale = options?.jawScale ?? 1.0;
-    const visemeJawAmounts = config.visemeJawAmounts;
+    const visemeJawAmounts = getVisemeJawAmounts(config);
 
     if (
       autoVisemeJaw &&
@@ -1823,7 +1832,7 @@ export class BakedAnimationController {
           let jawAmount = 0;
 
           // Sum contributions from all active visemes at time t
-          for (let visemeIdx = 0; visemeIdx < config.visemeKeys.length; visemeIdx++) {
+          for (let visemeIdx = 0; visemeIdx < visemeSlotCount; visemeIdx++) {
             const visemeCurve = curves[String(visemeIdx)];
             if (!visemeCurve) continue;
 

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -46,8 +46,10 @@ import { CC4_PRESET, CC4_MESHES, COMPOSITE_ROTATIONS as CC4_COMPOSITE_ROTATIONS 
 import { getPreset } from '../../presets';
 import { extendPresetWithProfile } from '../../mappings/extendPresetWithProfile';
 import {
+  getProfileVisemeSlots,
   getMeshNamesForAUProfile,
   getMeshNamesForVisemeProfile,
+  getVisemeBindingTargets,
   getVisemeJawAmounts,
   getVisemeSlotIndex,
 } from '../../mappings/visemeSystem';
@@ -89,6 +91,7 @@ function clamp01(x: number) {
 }
 
 type MorphTargetHandle = { infl: number[]; idx: number };
+type WeightedMorphTargetHandle = MorphTargetHandle & { weight: number };
 type ResolvedMorphTargetsBySide = {
   left: MorphTargetHandle[];
   right: MorphTargetHandle[];
@@ -142,7 +145,7 @@ export class Loom3 implements LoomLarge {
   private morphKeyCache = new Map<string, MorphTargetHandle[]>();
   private morphIndexCache = new Map<string, MorphTargetHandle[]>();
   private resolvedAUMorphTargets = new Map<number, ResolvedMorphTargetsBySide>();
-  private resolvedVisemeTargets: MorphTargetHandle[][] = [];
+  private resolvedVisemeTargets: WeightedMorphTargetHandle[][] = [];
 
   // Bones
   private bones: ResolvedBones = {};
@@ -335,12 +338,17 @@ export class Loom3 implements LoomLarge {
       this.resolvedAUMorphTargets.set(auId, resolved);
     }
 
-    for (let i = 0; i < (this.config.visemeKeys || []).length; i += 1) {
-      const key = this.config.visemeKeys[i];
+    for (let i = 0; i < getProfileVisemeSlots(this.config).length; i += 1) {
       const visemeMeshNames = this.getMeshNamesForViseme();
-      const targets = typeof key === 'number'
-        ? this.resolveMorphTargetsByIndex(key, visemeMeshNames)
-        : this.resolveMorphTargets(key, visemeMeshNames);
+      const targets: WeightedMorphTargetHandle[] = [];
+      for (const bindingTarget of getVisemeBindingTargets(this.config, i)) {
+        const resolved = typeof bindingTarget.morph === 'number'
+          ? this.resolveMorphTargetsByIndex(bindingTarget.morph, visemeMeshNames)
+          : this.resolveMorphTargets(bindingTarget.morph, visemeMeshNames);
+        for (const target of resolved) {
+          targets.push({ ...target, weight: bindingTarget.weight });
+        }
+      }
       this.resolvedVisemeTargets[i] = targets;
     }
   }
@@ -962,53 +970,34 @@ export class Loom3 implements LoomLarge {
   // ============================================================================
 
   setViseme(visemeIndex: number, value: number, jawScale = 1.0): void {
-    if (visemeIndex < 0 || visemeIndex >= this.config.visemeKeys.length) return;
+    if (visemeIndex < 0 || visemeIndex >= this.visemeValues.length) return;
 
     const val = clamp01(value);
     this.visemeValues[visemeIndex] = val;
     this.visemeJawScales[visemeIndex] = jawScale;
-
-    const targets = this.resolvedVisemeTargets[visemeIndex];
-    if (targets && targets.length > 0) {
-      this.applyMorphTargets(targets, val);
-    } else {
-      const morphKey = this.config.visemeKeys[visemeIndex];
-      const visemeMeshNames = this.getMeshNamesForViseme();
-      if (typeof morphKey === 'number') {
-        this.setMorphInfluence(morphKey, val, visemeMeshNames);
-      } else if (typeof morphKey === 'string') {
-        this.setMorph(morphKey, val, visemeMeshNames);
-      }
-    }
-
-    const jawAmount = this.getVisemeJawAmount(visemeIndex) * val * jawScale;
-    if (Math.abs(jawScale) > 1e-6 && Math.abs(jawAmount) > 1e-6) {
-      this.updateBoneRotation('JAW', 'pitch', jawAmount);
-    }
+    this.applyVisemeRuntimeState();
   }
 
   transitionViseme(visemeIndex: number, to: number, durationMs = 80, jawScale = 1.0): TransitionHandle {
-    if (visemeIndex < 0 || visemeIndex >= this.config.visemeKeys.length) {
+    if (visemeIndex < 0 || visemeIndex >= this.visemeValues.length) {
       return { promise: Promise.resolve(), pause: () => {}, resume: () => {}, cancel: () => {} };
     }
 
-    const morphKey = this.config.visemeKeys[visemeIndex];
     const target = clamp01(to);
-    this.visemeValues[visemeIndex] = target;
+    const from = this.visemeValues[visemeIndex] ?? 0;
     this.visemeJawScales[visemeIndex] = jawScale;
-    const visemeMeshNames = this.getMeshNamesForViseme();
 
-    const morphHandle = typeof morphKey === 'number'
-      ? this.transitionMorphInfluence(morphKey, target, durationMs, visemeMeshNames)
-      : this.transitionMorph(morphKey, target, durationMs, visemeMeshNames);
-
-    const jawAmount = this.getVisemeJawAmount(visemeIndex) * target * jawScale;
-    if (Math.abs(jawScale) <= 1e-6 || Math.abs(jawAmount) <= 1e-6) {
-      return morphHandle;
-    }
-
-    const jawHandle = this.transitionBoneRotation('JAW', 'pitch', jawAmount, durationMs);
-    return this.combineHandles([morphHandle, jawHandle]);
+    return this.animation.addTransition(
+      `viseme_value_${visemeIndex}`,
+      from,
+      target,
+      durationMs,
+      (value) => {
+        this.visemeValues[visemeIndex] = clamp01(value);
+        this.visemeJawScales[visemeIndex] = jawScale;
+        this.applyVisemeRuntimeState();
+      }
+    );
   }
 
   setVisemeById(slotId: string, value: number, jawScale = 1.0): void {
@@ -1069,8 +1058,9 @@ export class Loom3 implements LoomLarge {
 
   resetToNeutral(): void {
     this.auValues = {};
-    this.visemeValues = new Array(this.config.visemeKeys.length).fill(0);
-    this.visemeJawScales = new Array(this.config.visemeKeys.length).fill(1);
+    const visemeCount = getProfileVisemeSlots(this.config).length;
+    this.visemeValues = new Array(visemeCount).fill(0);
+    this.visemeJawScales = new Array(visemeCount).fill(1);
     this.translations = {};
     this.initBoneRotations();
     this.clearTransitions();
@@ -1110,11 +1100,7 @@ export class Loom3 implements LoomLarge {
       this.setAU(auId, value, this.auBalances[auId]);
     }
 
-    for (let visemeIndex = 0; visemeIndex < this.visemeValues.length; visemeIndex += 1) {
-      const value = this.visemeValues[visemeIndex] ?? 0;
-      if (value <= 0) continue;
-      this.setViseme(visemeIndex, value, this.visemeJawScales[visemeIndex] ?? 1);
-    }
+    this.applyVisemeRuntimeState();
 
     if (this.model) {
       this.flushPendingComposites();
@@ -1571,6 +1557,41 @@ export class Loom3 implements LoomLarge {
     }
   }
 
+  private applyVisemeRuntimeState(): void {
+    for (const targets of this.resolvedVisemeTargets) {
+      for (const target of targets || []) {
+        if (target.idx < target.infl.length) {
+          target.infl[target.idx] = 0;
+        }
+      }
+    }
+
+    for (let index = 0; index < this.visemeValues.length; index += 1) {
+      const value = clamp01(this.visemeValues[index] ?? 0);
+      if (value <= 1e-6) continue;
+      const targets = this.resolvedVisemeTargets[index] || [];
+      for (const target of targets) {
+        if (target.idx >= target.infl.length) continue;
+        const weighted = clamp01(value * target.weight);
+        target.infl[target.idx] = Math.max(target.infl[target.idx] ?? 0, weighted);
+      }
+    }
+
+    this.updateBoneRotation('JAW', 'pitch', this.getActiveVisemeJawAmount());
+  }
+
+  private getActiveVisemeJawAmount(): number {
+    let jawAmount = 0;
+    for (let index = 0; index < this.visemeValues.length; index += 1) {
+      const value = clamp01(this.visemeValues[index] ?? 0);
+      if (value <= 1e-6) continue;
+      const jawScale = this.visemeJawScales[index] ?? 1;
+      if (Math.abs(jawScale) <= 1e-6) continue;
+      jawAmount = Math.max(jawAmount, this.getVisemeJawAmount(index) * value * jawScale);
+    }
+    return jawAmount;
+  }
+
   private getMorphValue(key: string): number {
     if (this.faceMesh) {
       const dict = this.faceMesh.morphTargetDictionary;
@@ -1800,7 +1821,7 @@ export class Loom3 implements LoomLarge {
   }
 
   private syncVisemeRuntimeState(): void {
-    const visemeCount = this.config.visemeKeys.length;
+    const visemeCount = getProfileVisemeSlots(this.config).length;
     this.visemeValues = Array.from(
       { length: visemeCount },
       (_, index) => this.visemeValues[index] ?? 0

--- a/src/engines/three/Loom3.visemeRuntime.test.ts
+++ b/src/engines/three/Loom3.visemeRuntime.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D } from 'three';
+import type { Profile } from '../../mappings/types';
+import { Loom3 } from './Loom3';
+
+function makeMorphMesh(name: string, dictionary: Record<string, number>): Mesh {
+  const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
+  mesh.name = name;
+  (mesh as any).morphTargetDictionary = dictionary;
+  const maxIndex = Object.values(dictionary).length > 0 ? Math.max(...Object.values(dictionary)) : -1;
+  (mesh as any).morphTargetInfluences = maxIndex >= 0 ? new Array(maxIndex + 1).fill(0) : [];
+  return mesh;
+}
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    auToMorphs: {},
+    auToBones: {
+      26: [{ node: 'JAW', channel: 'rz', scale: 1, maxDegrees: 30 }],
+    },
+    boneNodes: { JAW: 'Jaw' },
+    morphToMesh: { face: [], viseme: ['VisemeMesh'] },
+    visemeKeys: ['Viseme_AA', 'Viseme_BMP'],
+    visemeSlots: [
+      { id: 'aa', label: 'AA', order: 0, defaultJawAmount: 0.8 },
+      { id: 'bmp', label: 'B/M/P', order: 1, defaultJawAmount: 0.2 },
+    ],
+    visemeMeshCategory: 'viseme',
+    visemeJawAmounts: [0.8, 0.2],
+    compositeRotations: [
+      {
+        node: 'JAW',
+        pitch: { aus: [26], axis: 'rz' },
+        yaw: null,
+        roll: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeEngine(profile: Profile, mesh: Mesh): Loom3 {
+  const model = new Object3D();
+  const jaw = new Object3D();
+  jaw.name = 'Jaw';
+  model.add(jaw, mesh);
+  const engine = new Loom3({ profile });
+  engine.onReady({ model, meshes: [mesh] });
+  return engine;
+}
+
+function jawRoll(engine: Loom3): number {
+  engine.update(1 / 60);
+  return Math.abs(engine.getBones().JAW.rotation[2]);
+}
+
+describe('Loom3 live viseme runtime', () => {
+  it('closes the jaw when a live viseme is set back to zero', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Viseme_AA: 0 });
+    const engine = makeEngine(makeProfile({ visemeKeys: ['Viseme_AA'], visemeJawAmounts: [0.8] }), mesh);
+
+    engine.setViseme(0, 1);
+    expect(jawRoll(engine)).toBeGreaterThan(20);
+
+    engine.setViseme(0, 0);
+    expect(jawRoll(engine)).toBeLessThan(0.001);
+    expect(mesh.morphTargetInfluences?.[0]).toBe(0);
+  });
+
+  it('transitions the jaw back to neutral when a live viseme target is zero', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Viseme_AA: 0 });
+    const engine = makeEngine(makeProfile({ visemeKeys: ['Viseme_AA'], visemeJawAmounts: [0.8] }), mesh);
+
+    engine.transitionViseme(0, 1, 0);
+    expect(jawRoll(engine)).toBeGreaterThan(20);
+
+    engine.transitionViseme(0, 0, 0);
+    expect(jawRoll(engine)).toBeLessThan(0.001);
+    expect(mesh.morphTargetInfluences?.[0]).toBe(0);
+  });
+
+  it('keeps jaw driven by the strongest active viseme contribution', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Viseme_AA: 0, Viseme_BMP: 1 });
+    const engine = makeEngine(makeProfile(), mesh);
+
+    engine.setViseme(0, 1);
+    const openJaw = jawRoll(engine);
+
+    engine.setViseme(1, 1);
+    expect(jawRoll(engine)).toBeCloseTo(openJaw, 4);
+    expect(mesh.morphTargetInfluences?.[0]).toBe(1);
+    expect(mesh.morphTargetInfluences?.[1]).toBe(1);
+
+    engine.setViseme(0, 0);
+    expect(jawRoll(engine)).toBeLessThan(openJaw);
+    expect(jawRoll(engine)).toBeGreaterThan(5);
+  });
+
+  it('drives one-to-many weighted viseme bindings by slot id', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Mouth_Aah: 0, Mouth_Wide: 1 });
+    const engine = makeEngine(makeProfile({
+      visemeKeys: ['Legacy_AA'],
+      visemeSlots: [{ id: 'aa', label: 'AA', order: 0, defaultJawAmount: 0.8 }],
+      visemeBindings: {
+        aa: {
+          targets: [
+            { morph: 'Mouth_Aah' },
+            { morph: 'Mouth_Wide', weight: 0.5 },
+          ],
+        },
+      },
+    }), mesh);
+
+    engine.setVisemeById('aa', 0.8);
+
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.8);
+    expect(mesh.morphTargetInfluences?.[1]).toBeCloseTo(0.4);
+  });
+
+  it('supports many-to-one bindings without letting the last slot overwrite stronger active values', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Shared_Mouth: 0 });
+    const engine = makeEngine(makeProfile({
+      visemeKeys: ['Legacy_AA', 'Legacy_BMP'],
+      visemeSlots: [
+        { id: 'aa', label: 'AA', order: 0, defaultJawAmount: 0.8 },
+        { id: 'bmp', label: 'B/M/P', order: 1, defaultJawAmount: 0.2 },
+      ],
+      visemeBindings: {
+        aa: { targets: [{ morph: 'Shared_Mouth' }] },
+        bmp: { targets: [{ morph: 'Shared_Mouth', weight: 0.5 }] },
+      },
+    }), mesh);
+
+    engine.setVisemeById('aa', 0.3);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.3);
+
+    engine.setVisemeById('bmp', 1);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.5);
+
+    engine.setVisemeById('bmp', 0);
+    expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.3);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ export {
   getMeshNamesForAUProfile,
   getMeshNamesForVisemeProfile,
   getProfileVisemeSlots,
+  getVisemeBindingTargets,
   getVisemeJawAmounts,
   getVisemeSlotIndex,
   mapProviderVisemeToSlot,
@@ -150,6 +151,7 @@ export {
 export type {
   ProviderVisemeEvent,
   ProviderVisemeMatch,
+  ResolvedVisemeBindingTarget,
 } from './mappings/visemeSystem';
 
 // ============================================================================

--- a/src/mappings/visemeSystem.test.ts
+++ b/src/mappings/visemeSystem.test.ts
@@ -5,6 +5,7 @@ import {
   compileVisemeKeys,
   getMeshNamesForVisemeProfile,
   getProfileVisemeSlots,
+  getVisemeBindingTargets,
   getVisemeSlotIndex,
   mapProviderVisemeToSlot,
   resolveVisemeMeshCategory,
@@ -59,6 +60,25 @@ describe('viseme system helpers', () => {
     });
 
     expect(compileVisemeKeys(profile)).toEqual(['Mouth_Aah', 'Mouth_Closed']);
+  });
+
+  it('resolves all weighted targets for runtime playback', () => {
+    const profile = makeProfile({
+      visemeBindings: {
+        aa: {
+          targets: [
+            { morph: 'Mouth_Aah' },
+            { morph: 'Mouth_Wide', weight: 0.5 },
+          ],
+        },
+      },
+    });
+
+    expect(getVisemeBindingTargets(profile, 0)).toEqual([
+      { morph: 'Mouth_Aah', weight: 1 },
+      { morph: 'Mouth_Wide', weight: 0.5 },
+    ]);
+    expect(getVisemeBindingTargets(profile, 1)).toEqual([{ morph: 'BMP', weight: 1 }]);
   });
 
   it('keeps explicit empty viseme mesh routes authoritative', () => {

--- a/src/mappings/visemeSystem.ts
+++ b/src/mappings/visemeSystem.ts
@@ -29,6 +29,15 @@ function bindingTargets(binding: VisemeBinding | undefined): MorphTargetRef[] {
   return binding.morph !== undefined && binding.morph !== '' ? [binding.morph] : [];
 }
 
+export interface ResolvedVisemeBindingTarget {
+  morph: MorphTargetRef;
+  weight: number;
+}
+
+function normalizeBindingWeight(weight: number | undefined): number {
+  return Number.isFinite(weight) ? Math.max(0, weight ?? 1) : 1;
+}
+
 export function getProfileVisemeSlots(profile: Profile): VisemeSlot[] {
   if (profile.visemeSlots && profile.visemeSlots.length > 0) {
     return [...profile.visemeSlots].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
@@ -57,6 +66,32 @@ export function compileVisemeKeys(profile: Profile): MorphTargetRef[] {
     const target = bindingTargets(profile.visemeBindings?.[slot.id])[0];
     return target ?? profile.visemeKeys?.[index] ?? '';
   });
+}
+
+export function getVisemeBindingTargets(profile: Profile, visemeIndex: number): ResolvedVisemeBindingTarget[] {
+  const slots = getProfileVisemeSlots(profile);
+  const slot = slots[visemeIndex];
+  const binding = slot ? profile.visemeBindings?.[slot.id] : undefined;
+
+  const boundTargets = binding?.targets
+    ?.filter((target) => target.morph !== undefined && target.morph !== '')
+    .map((target) => ({
+      morph: target.morph,
+      weight: normalizeBindingWeight(target.weight),
+    }));
+
+  if (boundTargets && boundTargets.length > 0) {
+    return boundTargets;
+  }
+
+  if (binding?.morph !== undefined && binding.morph !== '') {
+    return [{ morph: binding.morph, weight: 1 }];
+  }
+
+  const legacyTarget = profile.visemeKeys?.[visemeIndex];
+  return legacyTarget !== undefined && legacyTarget !== ''
+    ? [{ morph: legacyTarget, weight: 1 }]
+    : [];
 }
 
 export function getVisemeJawAmounts(profile: Profile): number[] | undefined {


### PR DESCRIPTION
## Summary

Fixes #134.

- Add a shared `getVisemeBindingTargets()` resolver that preserves all profile-defined viseme binding targets and weights while keeping the legacy `visemeKeys[index]` fallback.
- Rework live `setViseme()` / `transitionViseme()` to drive the whole active viseme state instead of independent one-off morph and jaw transitions.
- Use strongest-active viseme jaw aggregation for live playback so returning a viseme to zero closes the jaw and overlapping visemes do not let the last write incorrectly win.
- Update baked viseme snippet generation to use the same binding resolver, including one-to-many weighted bindings and slot-defined jaw amounts.
- Add tests for jaw reset, transition-to-zero jaw behavior, strongest-active jaw behavior, one-to-many bindings, many-to-one bindings, and baked weighted binding tracks.

## Notes

This preserves the existing index APIs for compatibility. `setVisemeById()` and `transitionVisemeById()` now benefit from the shared binding resolver through the underlying runtime path.

## Validation

- `npm ci`
- `npm test -- --run src/mappings/visemeSystem.test.ts src/engines/three/Loom3.visemeRuntime.test.ts src/engines/three/AnimationThree.meshSelection.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`