### PR TITLE
[codex] Harden dynamic clip parameter updates

### DIFF
--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   AnimationClip,
   BufferGeometry,
@@ -116,6 +116,13 @@ function makeSceneClip(camera: Object3D, name: string): AnimationClip {
     new NumberKeyframeTrack(`${camera.uuid}.position[x]`, [0, 1], [0, 1]),
   ]);
 }
+
+const smileCurves = {
+  smile: [
+    { time: 0, intensity: 0 },
+    { time: 1, intensity: 1 },
+  ],
+};
 
 describe('BakedAnimationController playback state normalization', () => {
   it('normalizes baked clip options into the shared animation state surface', () => {
@@ -375,5 +382,83 @@ describe('BakedAnimationController playback state normalization', () => {
 
     handle?.play();
     expect(controller.getAnimationState('Wave')?.time).toBeCloseTo(1, 5);
+  });
+
+  it('updates an active dynamic clip weight by actionId without rebuilding or touching name matches', () => {
+    const { controller } = makeHost();
+    const firstHandle = controller.buildClip('gesture', smileCurves, {
+      loopMode: 'repeat',
+      weight: 1,
+    });
+    const secondHandle = controller.buildClip('gesture_alt', smileCurves, {
+      loopMode: 'repeat',
+      weight: 1,
+    });
+    expect(firstHandle?.actionId).toBeTruthy();
+    expect(secondHandle?.actionId).toBeTruthy();
+
+    controller.seekAnimation('gesture', 0.5);
+    const buildSpy = vi.spyOn(controller, 'buildClip');
+
+    expect(controller.updateClipParams('gesture', {
+      actionId: secondHandle!.actionId,
+      weight: 0.25,
+    })).toBe(true);
+
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(controller.getAnimationState('gesture')).toMatchObject({
+      actionId: firstHandle!.actionId,
+      weight: 1,
+      time: 0.5,
+    });
+    expect(controller.getAnimationState('gesture_alt')).toMatchObject({
+      actionId: secondHandle!.actionId,
+      weight: 0.25,
+    });
+  });
+
+  it('updates dynamic clip repeat count and reverse playback without resetting loop mode or time', () => {
+    const { controller } = makeHost();
+    const handle = controller.buildClip('loopingGesture', smileCurves, {
+      loopMode: 'repeat',
+      repeatCount: 5,
+      playbackRate: 2,
+      reverse: false,
+      weight: 0.8,
+    });
+    expect(handle?.actionId).toBeTruthy();
+
+    controller.seekAnimation('loopingGesture', 0.4);
+
+    expect(controller.updateClipParams('loopingGesture', { repeatCount: 2 })).toBe(true);
+    expect(controller.getAnimationState('loopingGesture')).toMatchObject({
+      loopMode: 'repeat',
+      repeatCount: 2,
+      playbackRate: 2,
+      reverse: false,
+      weight: 0.8,
+      time: 0.4,
+    });
+
+    expect(controller.updateClipParams('loopingGesture', { reverse: true })).toBe(true);
+    expect(controller.getAnimationState('loopingGesture')).toMatchObject({
+      loopMode: 'repeat',
+      repeatCount: 2,
+      playbackRate: 2,
+      reverse: true,
+      weight: 0.8,
+      time: 0.4,
+    });
+  });
+
+  it('returns false when no active dynamic clip matches the requested actionId', () => {
+    const { controller } = makeHost();
+    controller.buildClip('gesture', smileCurves);
+
+    expect(controller.updateClipParams('gesture', {
+      actionId: 'missing-action',
+      weight: 0.5,
+    })).toBe(false);
+    expect(controller.getAnimationState('gesture')).toMatchObject({ weight: 1 });
   });
 });

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -2044,6 +2044,7 @@ export class BakedAnimationController {
 
     if (actionId) {
       this.cleanupClipMonitor(actionId);
+      this.actionIdToClip.set(actionId, clip.name);
     }
 
     let resolveFinished!: () => void;
@@ -2218,13 +2219,15 @@ export class BakedAnimationController {
   }
 
   updateClipParams(name: string, params: { weight?: number; rate?: number; loop?: boolean; loopMode?: 'once' | 'repeat' | 'pingpong'; repeatCount?: number; reverse?: boolean; actionId?: string }): boolean {
-    let updated = false;
-    const matches = (clipName: string, action?: AnimationAction | null) => {
-      if (params.actionId) {
-        const aid = action ? this.actionIds.get(action) : this.actionIdToClip.get(params.actionId);
-        if (aid && aid === params.actionId) return true;
-      }
-      return clipName === name || clipName.startsWith(`${name}_`) || clipName.includes(name);
+    const targetActionId = params.actionId;
+    const targets: Array<{ clipName: string; action: AnimationAction }> = [];
+    const seenActions = new Set<AnimationAction>();
+    const matchesName = (clipName: string) =>
+      clipName === name || clipName.startsWith(`${name}_`) || clipName.includes(name);
+    const addTarget = (clipName: string, action: AnimationAction | undefined) => {
+      if (!action || seenActions.has(action)) return;
+      seenActions.add(action);
+      targets.push({ clipName, action });
     };
 
     const debugSnapshot = () => ({
@@ -2241,64 +2244,96 @@ export class BakedAnimationController {
 
     console.log('[Loom3] updateClipParams start', debugSnapshot());
 
-    const apply = (action: AnimationAction | null | undefined) => {
-      if (!action) return;
+    if (targetActionId) {
+      for (const [clipName, action] of this.clipActions.entries()) {
+        if (this.getActionId(action) === targetActionId) addTarget(clipName, action);
+      }
+      for (const [clipName, action] of this.animationActions.entries()) {
+        if (this.getActionId(action) === targetActionId) addTarget(clipName, action);
+      }
+
+      if (targets.length === 0) {
+        const clipName = this.actionIdToClip.get(targetActionId);
+        if (clipName) {
+          addTarget(clipName, this.clipActions.get(clipName));
+          addTarget(clipName, this.animationActions.get(clipName));
+        }
+      }
+    } else {
+      for (const [clipName, action] of this.clipActions.entries()) {
+        if (matchesName(clipName)) addTarget(clipName, action);
+      }
+      for (const [clipName, action] of this.animationActions.entries()) {
+        if (matchesName(clipName)) addTarget(clipName, action);
+      }
+    }
+
+    if (targets.length === 0) {
+      console.log('[Loom3] updateClipParams end', debugSnapshot());
+      return false;
+    }
+
+    const apply = (clipName: string, action: AnimationAction) => {
       const actionId = this.getActionId(action);
       const monitor = actionId ? this.clipMonitors.get(actionId) : undefined;
-      const clipName = action.getClip().name;
-      const next = this.playbackState.get(clipName)
+      const actionClipName = action.getClip().name;
+      const stateName = this.playbackState.has(clipName) ? clipName : actionClipName;
+      const next = this.playbackState.get(stateName)
         ?? this.normalizePlaybackOptions(undefined, { loop: false, source: this.clipSources.get(clipName) ?? 'clip' });
+
       try { action.paused = false; } catch {}
+
       if (typeof params.weight === 'number' && Number.isFinite(params.weight)) {
-        action.setEffectiveWeight(params.weight);
         next.weight = Math.max(0, params.weight);
-        updated = true;
+        action.setEffectiveWeight(next.weight);
       }
-      if (typeof params.rate === 'number' && Number.isFinite(params.rate)) {
-        next.playbackRate = Math.max(0, Math.abs(params.rate));
-        if (typeof params.reverse === 'boolean') {
-          next.reverse = params.reverse;
-        }
+
+      const hasRateUpdate = typeof params.rate === 'number' && Number.isFinite(params.rate);
+      const hasReverseUpdate = typeof params.reverse === 'boolean';
+      if (hasRateUpdate) {
+        next.playbackRate = Math.max(0, Math.abs(params.rate!));
+      }
+      if (hasReverseUpdate) {
+        next.reverse = params.reverse!;
+      }
+      if (hasRateUpdate || hasReverseUpdate) {
         const signedRate = next.reverse ? -next.playbackRate : next.playbackRate;
         action.setEffectiveTimeScale(signedRate);
         if (monitor) {
           monitor.direction = next.reverse ? -1 : 1;
           monitor.initialDirection = monitor.direction;
         }
-        updated = true;
       }
-      if (typeof params.loop === 'boolean' || params.loopMode || params.repeatCount !== undefined) {
-        next.loopMode = params.loopMode || (params.loop ? 'repeat' : 'once');
-        next.loop = next.loopMode !== 'once';
-        next.repeatCount = params.repeatCount;
+
+      let shouldApplyLoopState = false;
+      const requestedLoopMode = params.loopMode
+        ?? (typeof params.loop === 'boolean' ? (params.loop ? 'repeat' : 'once') : undefined);
+      if (requestedLoopMode) {
+        next.loopMode = requestedLoopMode;
+        next.loop = requestedLoopMode !== 'once';
+        shouldApplyLoopState = true;
+      }
+      if (params.repeatCount !== undefined) {
+        next.repeatCount = typeof params.repeatCount === 'number' && Number.isFinite(params.repeatCount)
+          ? Math.max(0, params.repeatCount)
+          : undefined;
+        shouldApplyLoopState = true;
+      }
+
+      if (shouldApplyLoopState) {
         this.applyPlaybackState(action, next);
         if (monitor) monitor.loopMode = next.loopMode;
-        updated = true;
       }
-      this.setPlaybackState(clipName, next);
+
+      this.setPlaybackState(stateName, next);
     };
 
-    for (const [clipName, action] of this.clipActions.entries()) {
-      if (matches(clipName, action)) {
-        apply(action);
-      }
-    }
-    for (const [clipName, action] of this.animationActions.entries()) {
-      if (matches(clipName, action)) {
-        apply(action);
-      }
-    }
-
-    if (!updated && params.actionId) {
-      const clipName = this.actionIdToClip.get(params.actionId);
-      if (clipName) {
-        const action = this.clipActions.get(clipName) || this.animationActions.get(clipName);
-        if (action) apply(action);
-      }
+    for (const { clipName, action } of targets) {
+      apply(clipName, action);
     }
 
     console.log('[Loom3] updateClipParams end', debugSnapshot());
-    return updated;
+    return true;
   }
 
   private addMorphTracks(

--- a/src/interfaces/Animation.ts
+++ b/src/interfaces/Animation.ts
@@ -381,7 +381,7 @@ export interface Animation {
    * Update parameters on an active clip.
    * @param name - Name of the clip to update
    * @param params - Parameters to update
-   * @returns true if clip was found and updated
+   * @returns true if a matching active clip/action was found
    */
   updateClipParams(
     name: string,


### PR DESCRIPTION
## Summary

Fixes #116.

This hardens `updateClipParams()` for scheduler-driven dynamic clips so active snippet/clip actions can be adjusted without rebuilding their underlying clips.

## What changed

- Treat `actionId` as an exact selector instead of also updating broad name matches.
- Dedupe the same mixer action when it appears in both internal action maps.
- Preserve the current loop mode when only `repeatCount` changes.
- Support `reverse` updates without requiring a simultaneous rate update.
- Keep dynamic clip weight updates on the active mixer action through `setEffectiveWeight()`.
- Return `false` only when no active clip/action target can be found.
- Add regression coverage for actionId targeting, no-rebuild weight updates, repeat/reverse updates, and missing action IDs.

## Validation

- `npx vitest run src/engines/three/AnimationThree.playbackState.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`