### PR TITLE
[codex] Support inherited keyframes and clarify mixer controller naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1892,6 +1892,18 @@ if (clip) {
 }
 ```
 
+When the first keyframe has `inherit: true`, Loom3 anchors that first mixer
+track value to the character's current live target value instead of treating the
+placeholder intensity as a real reset. The following keyframes remain authored
+targets:
+
+```typescript
+const handle = loom.buildClip('smile-from-current-pose', {
+  // Starts from the current AU 12/morph/bone state, then moves to 0.7.
+  '12': [{ time: 0, intensity: 0, inherit: true }, { time: 0.25, intensity: 0.7 }],
+}, { loop: false });
+```
+
 Clip stream events are discrete runtime events, not a polling surface:
 
 - `keyframe` fires when playback crosses an authored keyframe.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Loom3 is broader than a face-controller wrapper. The library spans four practica
 - Runtime control: Action Units, visemes, direct morphs, continuum pairs, composite rotations, transitions, and mixer playback.
 - Rig configuration: built-in presets, profile overrides, preset lookup and extension, name resolution, viseme routing, mix weights, and skeletal-only preset support.
 - Inspection and validation: mesh, morph, and bone discovery; preset-fit checks; correction suggestions; and full model analysis.
-- Runtime tooling: mesh/material debugging, baked animation clip helpers, hair physics, and region/geometry helpers for annotation or camera tooling.
+- Runtime tooling: mesh/material debugging, mixer animation clip helpers, hair physics, and region/geometry helpers for annotation or camera tooling.
 
 ## Reading Paths
 
@@ -1870,7 +1870,7 @@ Loom3 can convert AU/morph curves into AnimationMixer clips for smooth, mixer-on
 Key APIs:
 - `snippetToClip(name, curves, options)` builds an AnimationClip from curves.
 - `playClip(clip, options)` returns a ClipHandle you can pause/resume/stop.
-- `clipHandle.subscribe(listener)` streams lifecycle events from the runtime update loop.
+- `clipHandle.subscribe(listener)` streams lifecycle events during mixer updates.
 - `clipHandle.stop()` now resolves cleanly (no rejected promise).
 
 ```typescript
@@ -2056,7 +2056,7 @@ const state = loom.getAnimationState('Idle');
 
 ### Combining with facial animation
 
-Baked animations and facial AU control work together seamlessly. The AnimationMixer updates automatically when you call `loom.update()` or use `loom.start()`:
+Loaded mixer clips and facial AU control work together seamlessly. The AnimationMixer updates automatically when you call `loom.update()` or use `loom.start()`:
 
 ```typescript
 loom.loadAnimationClips(gltf.animations);

--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -12,7 +12,7 @@
 
 ### Playback and mixer updates
 - Clip stop now resolves cleanly, so stopping playback does not throw a rejected promise.
-- Clip handles now expose `subscribe()` for keyframe, loop, seek, and completion events from the runtime update loop.
+- Clip handles now expose `subscribe()` for keyframe, loop, seek, and completion events during mixer updates.
 - Eye and head tracking clips stay cached on stop to avoid pose resets during continuous tracking.
 - Snippet-to-clip conversion supports UUID-based tracks for bones, which avoids dot-name binding issues.
 - Curves can be played through the mixer via `snippetToClip()` + `playClip()`, including composite bone rotations.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -322,7 +322,11 @@ export interface CurvePoint {
   time: number;
   /** Intensity value (0-1) */
   intensity: number;
-  /** When true, inherit current AU value at playback start */
+  /**
+   * When true on the first keyframe, capture the driven target's current live
+   * value at clip construction/playback start and transition from that anchor
+   * into the following authored keyframes.
+   */
   inherit?: boolean;
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -134,10 +134,10 @@ export type AnimationSource = 'baked' | 'clip' | 'snippet';
 /** Shared blend-mode surface for downstream animation UIs. */
 export type AnimationBlendMode = 'replace' | 'additive';
 
-/** Runtime channel classes derived from one authored baked source clip. */
+/** Mixer channel classes derived from one authored baked source clip. */
 export type BakedClipChannel = 'face' | 'body' | 'scene';
 
-/** Metadata describing one derived baked runtime channel. */
+/** Metadata describing one derived baked mixer channel. */
 export interface BakedClipChannelInfo {
   /** Logical channel key surfaced to downstream UIs. */
   channel: BakedClipChannel;
@@ -153,16 +153,16 @@ export interface BakedClipChannelInfo {
 export type AnimationEasing = 'linear' | 'easeInOut' | 'easeInOutCubic' | 'easeIn' | 'easeOut';
 
 /**
- * Options for playing a baked animation clip.
+ * Options for playing a mixer animation clip.
  */
 export interface AnimationPlayOptions {
   /** Playback speed multiplier (default: 1.0). Alias: playbackRate. */
   speed?: number;
-  /** Alias for speed so baked clips and snippet clips can share one UI contract. */
+  /** Alias for speed so loaded clips and dynamic clips can share one UI contract. */
   playbackRate?: number;
   /** Animation intensity/weight (default: 1.0). Alias: weight. */
   intensity?: number;
-  /** Alias for intensity so baked clips and snippet clips can share one UI contract. */
+  /** Alias for intensity so loaded clips and dynamic clips can share one UI contract. */
   weight?: number;
   /** Whether the animation should loop (default: true) */
   loop?: boolean;
@@ -347,7 +347,7 @@ export interface ClipOptions {
   repeatCount?: number;
   /** Playback rate multiplier (default: 1.0) */
   playbackRate?: number;
-  /** Alias for playbackRate so clip-backed animations can share one UI contract with baked clips. */
+  /** Alias for playbackRate so dynamic clips can share one UI contract with loaded clips. */
   speed?: number;
   /** Play clip backwards when true (implemented via negative time scale) */
   reverse?: boolean;
@@ -420,7 +420,7 @@ export interface ClipHandle {
   getTime: () => number;
   /** Get total clip duration in seconds */
   getDuration: () => number;
-  /** Subscribe to clip lifecycle events emitted by the runtime update loop */
+  /** Subscribe to clip lifecycle events emitted during mixer updates */
   subscribe?: (listener: ClipEventListener) => () => void;
   /** Promise that resolves when clip finishes (non-looping only) */
   finished: Promise<void>;

--- a/src/engines/three/AnimationThree.balanceMap.test.ts
+++ b/src/engines/three/AnimationThree.balanceMap.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D } from 'three';
 import type { Profile } from '../../mappings/types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
-function makeHost(): { host: BakedAnimationHost; mesh: Mesh } {
+function makeHost(): { host: AnimationControllerHost; mesh: Mesh } {
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
   mesh.name = 'FaceMesh';
   (mesh as any).morphTargetDictionary = {
@@ -25,7 +25,7 @@ function makeHost(): { host: BakedAnimationHost; mesh: Mesh } {
     visemeKeys: [],
   };
 
-  const host: BakedAnimationHost = {
+  const host: AnimationControllerHost = {
     getModel: () => new Object3D(),
     getMeshes: () => [mesh],
     getMeshByName: (name: string) => (name === 'FaceMesh' ? mesh : undefined),
@@ -46,10 +46,10 @@ function getTrackValues(clip: any, morphIndex: number): number[] {
   return Array.from(track.values as ArrayLike<number>);
 }
 
-describe('BakedAnimationController snippetToClip balanceMap', () => {
+describe('AnimationController snippetToClip balanceMap', () => {
   it('applies per-AU balance overrides while preserving global fallback', () => {
     const { host } = makeHost();
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const curves = {
       12: [
         { time: 0, intensity: 0 },

--- a/src/engines/three/AnimationThree.clipEvents.test.ts
+++ b/src/engines/three/AnimationThree.clipEvents.test.ts
@@ -3,7 +3,7 @@ import { Object3D, Quaternion } from 'three';
 import type { Profile } from '../../mappings/types';
 import { BONE_AU_TO_BINDINGS, COMPOSITE_ROTATIONS } from '../../presets/cc4';
 import type { ResolvedBones } from './types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 function snapshot(obj: Object3D) {
   return {
@@ -14,7 +14,7 @@ function snapshot(obj: Object3D) {
   };
 }
 
-function makeHost(): BakedAnimationHost {
+function makeHost(): AnimationControllerHost {
   const model = new Object3D();
   const leftEye = new Object3D();
   leftEye.name = 'CC_Base_L_Eye';
@@ -45,9 +45,9 @@ function makeHost(): BakedAnimationHost {
   };
 }
 
-describe('BakedAnimationController clip events', () => {
+describe('AnimationController clip events', () => {
   it('emits keyframe and completion events from mixer updates', () => {
-    const controller = new BakedAnimationController(makeHost());
+    const controller = new AnimationController(makeHost());
     const clip = controller.snippetToClip('eye-event-clip', {
       61: [
         { time: 0, intensity: 0 },
@@ -99,7 +99,7 @@ describe('BakedAnimationController clip events', () => {
   });
 
   it('emits seek events when the playhead is scrubbed directly', () => {
-    const controller = new BakedAnimationController(makeHost());
+    const controller = new AnimationController(makeHost());
     const clip = controller.snippetToClip('seek-event-clip', {
       61: [
         { time: 0, intensity: 0 },

--- a/src/engines/three/AnimationThree.compositeAxisGroups.test.ts
+++ b/src/engines/three/AnimationThree.compositeAxisGroups.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { Object3D, Quaternion } from 'three';
 import type { Profile } from '../../mappings/types';
 import type { ResolvedBones } from './types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
-function makeHost(): { controller: BakedAnimationController; bones: ResolvedBones } {
+function makeHost(): { controller: AnimationController; bones: ResolvedBones } {
   const head = new Object3D();
   head.name = 'Head';
 
@@ -38,7 +38,7 @@ function makeHost(): { controller: BakedAnimationController; bones: ResolvedBone
     ],
   };
 
-  const host: BakedAnimationHost = {
+  const host: AnimationControllerHost = {
     getModel: () => new Object3D(),
     getMeshes: () => [],
     getMeshByName: () => undefined,
@@ -50,16 +50,16 @@ function makeHost(): { controller: BakedAnimationController; bones: ResolvedBone
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), bones };
+  return { controller: new AnimationController(host), bones };
 }
 
-function getTrackComponent(clip: NonNullable<ReturnType<BakedAnimationController['snippetToClip']>>, obj: Object3D, componentIndex: number) {
+function getTrackComponent(clip: NonNullable<ReturnType<AnimationController['snippetToClip']>>, obj: Object3D, componentIndex: number) {
   const track = clip.tracks.find((entry) => entry.name === `${(obj as any).uuid}.quaternion`);
   expect(track).toBeTruthy();
   return Array.from((track!.values as ArrayLike<number>)).slice(-4)[componentIndex];
 }
 
-describe('BakedAnimationController grouped composite rotation axes', () => {
+describe('AnimationController grouped composite rotation axes', () => {
   it('uses grouped negative/positive AUs when baking quaternion tracks', () => {
     const negative = makeHost();
     const negativeClip = negative.controller.snippetToClip('grouped-negative', {

--- a/src/engines/three/AnimationThree.eyeBalance.test.ts
+++ b/src/engines/three/AnimationThree.eyeBalance.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { Euler, Object3D, Quaternion } from 'three';
 import type { Profile } from '../../mappings/types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 function makeEyeBoneHost(): {
-  controller: BakedAnimationController;
+  controller: AnimationController;
   eyeL: Object3D;
   eyeR: Object3D;
 } {
@@ -55,7 +55,7 @@ function makeEyeBoneHost(): {
     compositeRotations: compositeRotations as any,
   };
 
-  const host: BakedAnimationHost = {
+  const host: AnimationControllerHost = {
     getModel: () => new Object3D(),
     getMeshes: () => [],
     getMeshByName: () => undefined,
@@ -85,7 +85,7 @@ function makeEyeBoneHost(): {
   };
 
   return {
-    controller: new BakedAnimationController(host),
+    controller: new AnimationController(host),
     eyeL,
     eyeR,
   };
@@ -107,7 +107,7 @@ function getRotationDegrees(clip: any, obj: Object3D): [number, number, number] 
   ];
 }
 
-describe('BakedAnimationController eye balance', () => {
+describe('AnimationController eye balance', () => {
   it('applies snippet balance to bilateral eye bone tracks', () => {
     const { controller, eyeL, eyeR } = makeEyeBoneHost();
 

--- a/src/engines/three/AnimationThree.eyeBones.test.ts
+++ b/src/engines/three/AnimationThree.eyeBones.test.ts
@@ -3,7 +3,7 @@ import { Object3D, Quaternion } from 'three';
 import type { Profile } from '../../mappings/types';
 import { BONE_AU_TO_BINDINGS, COMPOSITE_ROTATIONS } from '../../presets/cc4';
 import type { ResolvedBones } from './types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 const INDEPENDENT_EYE_CASES = [
   { auId: 65, trackNode: 'EYE_L', otherNode: 'EYE_R', label: 'left-eye yaw' },
@@ -21,7 +21,7 @@ function snapshot(obj: Object3D) {
   };
 }
 
-function makeHost(): { host: BakedAnimationHost; bones: ResolvedBones } {
+function makeHost(): { host: AnimationControllerHost; bones: ResolvedBones } {
   const model = new Object3D();
   const leftEye = new Object3D();
   const rightEye = new Object3D();
@@ -43,7 +43,7 @@ function makeHost(): { host: BakedAnimationHost; bones: ResolvedBones } {
     visemeKeys: [],
   };
 
-  const host: BakedAnimationHost = {
+  const host: AnimationControllerHost = {
     getModel: () => model,
     getMeshes: () => [],
     getMeshByName: () => undefined,
@@ -58,10 +58,10 @@ function makeHost(): { host: BakedAnimationHost; bones: ResolvedBones } {
   return { host, bones };
 }
 
-describe('BakedAnimationController independent eye bone rotations', () => {
+describe('AnimationController independent eye bone rotations', () => {
   it.each(INDEPENDENT_EYE_CASES)('emits only the intended eye quaternion track for $label', ({ auId, trackNode, otherNode }) => {
     const { host, bones } = makeHost();
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
 
     const clip = controller.snippetToClip(`eye-${auId}`, {
       [auId]: [
@@ -87,7 +87,7 @@ describe('BakedAnimationController independent eye bone rotations', () => {
 
   it('keeps shared eye AUs driving both eye quaternion tracks', () => {
     const { host, bones } = makeHost();
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
 
     const clip = controller.snippetToClip('shared-eyes', {
       61: [

--- a/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
+++ b/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from 'vitest';
+import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D, Quaternion, Vector3 } from 'three';
+import type { Profile } from '../../mappings/types';
+import type { ResolvedBones } from './types';
+import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+
+function makeMorphMesh(name: string, dictionary: Record<string, number>): Mesh {
+  const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
+  mesh.name = name;
+  (mesh as any).morphTargetDictionary = dictionary;
+  const maxIndex = Object.values(dictionary).length > 0 ? Math.max(...Object.values(dictionary)) : -1;
+  (mesh as any).morphTargetInfluences = maxIndex >= 0 ? new Array(maxIndex + 1).fill(0) : [];
+  return mesh;
+}
+
+function makeBone(name = 'Head') {
+  const obj = new Object3D();
+  obj.name = name;
+  return {
+    obj,
+    basePos: { x: 0, y: 0, z: 0 },
+    baseQuat: new Quaternion(),
+    baseEuler: { x: 0, y: 0, z: 0, order: 'XYZ' as const },
+  };
+}
+
+function makeHost({
+  profile,
+  meshes = [],
+  bones = {},
+  auValues = {},
+  visemeValues = [],
+}: {
+  profile: Profile;
+  meshes?: Mesh[];
+  bones?: ResolvedBones;
+  auValues?: Record<number, number>;
+  visemeValues?: number[];
+}): BakedAnimationHost {
+  const model = new Object3D();
+  for (const mesh of meshes) model.add(mesh);
+  for (const bone of Object.values(bones)) {
+    if (bone) model.add(bone.obj);
+  }
+  const meshMap = new Map(meshes.map((mesh) => [mesh.name, mesh]));
+
+  const readMorph = (morphKey: string, meshNames?: string[]) => {
+    const names = meshNames ?? profile.morphToMesh?.face ?? [];
+    for (const name of names) {
+      const mesh = meshMap.get(name);
+      const dict = mesh?.morphTargetDictionary;
+      const infl = mesh?.morphTargetInfluences;
+      if (!dict || !infl || dict[morphKey] === undefined) continue;
+      return infl[dict[morphKey]] ?? 0;
+    }
+    return 0;
+  };
+
+  const readMorphIndex = (morphIndex: number, meshNames?: string[]) => {
+    const names = meshNames ?? profile.morphToMesh?.face ?? [];
+    for (const name of names) {
+      const infl = meshMap.get(name)?.morphTargetInfluences;
+      if (!infl || morphIndex < 0 || morphIndex >= infl.length) continue;
+      return infl[morphIndex] ?? 0;
+    }
+    return 0;
+  };
+
+  return {
+    getModel: () => model,
+    getMeshes: () => meshes,
+    getMeshByName: (name: string) => meshMap.get(name),
+    getCurrentAUValue: (auId: number) => auValues[auId] ?? 0,
+    getCurrentVisemeValue: (visemeIndex: number) => visemeValues[visemeIndex] ?? 0,
+    getCurrentMorphValue: readMorph,
+    getCurrentMorphIndexValue: readMorphIndex,
+    getCurrentBoneQuaternion: (nodeKey: string) => bones[nodeKey]?.obj.quaternion.clone() ?? null,
+    getCurrentBonePositionValue: (nodeKey: string, axis: 'x' | 'y' | 'z') => bones[nodeKey]?.obj.position[axis] ?? null,
+    getBones: () => bones,
+    getConfig: () => profile,
+    getCompositeRotations: () => profile.compositeRotations || [],
+    computeSideValues: (base: number) => ({ left: base, right: base }),
+    getAUMixWeight: () => 1,
+    isMixedAU: () => false,
+  };
+}
+
+function getNumberTrackValues(clip: NonNullable<ReturnType<BakedAnimationController['snippetToClip']>>, trackNamePart: string): number[] {
+  const track = clip.tracks.find((entry) => entry.name.includes(trackNamePart));
+  expect(track).toBeTruthy();
+  return Array.from(track!.values as ArrayLike<number>);
+}
+
+function getQuaternionTrackValues(clip: NonNullable<ReturnType<BakedAnimationController['snippetToClip']>>, obj: Object3D): number[] {
+  const track = clip.tracks.find((entry) => entry.name === `${(obj as any).uuid}.quaternion`);
+  expect(track).toBeTruthy();
+  return Array.from(track!.values as ArrayLike<number>);
+}
+
+describe('BakedAnimationController inherited first keyframes', () => {
+  it('anchors direct morph curves to the current morph value', () => {
+    const mesh = makeMorphMesh('Face', { Smile: 0 });
+    mesh.morphTargetInfluences![0] = 0.42;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['Face'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+
+    const clip = controller.snippetToClip('direct-inherit', {
+      Smile: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const values = getNumberTrackValues(clip!, `${(mesh as any).uuid}.morphTargetInfluences[0]`);
+    expect(values[0]).toBeCloseTo(0.42);
+    expect(values[1]).toBeCloseTo(1);
+  });
+
+  it('keeps non-inherited direct morph curves absolute', () => {
+    const mesh = makeMorphMesh('Face', { Smile: 0 });
+    mesh.morphTargetInfluences![0] = 0.42;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['Face'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+
+    const clip = controller.snippetToClip('direct-absolute', {
+      Smile: [
+        { time: 0, intensity: 0 },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const values = getNumberTrackValues(clip!, `${(mesh as any).uuid}.morphTargetInfluences[0]`);
+    expect(values).toEqual([0, 1]);
+  });
+
+  it('anchors AU-to-morph tracks to the current target morph value', () => {
+    const mesh = makeMorphMesh('Face', { Smile: 0 });
+    mesh.morphTargetInfluences![0] = 0.55;
+    const profile: Profile = {
+      auToMorphs: {
+        12: { left: [], right: [], center: ['Smile'] },
+      },
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['Face'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh], auValues: { 12: 0.55 } }));
+
+    const clip = controller.snippetToClip('au-morph-inherit', {
+      12: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 0.8 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const values = getNumberTrackValues(clip!, `${(mesh as any).uuid}.morphTargetInfluences[0]`);
+    expect(values[0]).toBeCloseTo(0.55);
+    expect(values[1]).toBeCloseTo(0.8);
+  });
+
+  it('anchors auto viseme jaw tracks to the current jaw quaternion', () => {
+    const jaw = makeBone('Jaw');
+    jaw.obj.quaternion.copy(new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), 0.4));
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {
+        26: [{ node: 'JAW', channel: 'rz', scale: 1, maxDegrees: 30 }],
+      },
+      boneNodes: { JAW: 'Jaw' },
+      morphToMesh: {},
+      visemeKeys: ['AA'],
+      visemeJawAmounts: [1],
+    };
+    const controller = new BakedAnimationController(makeHost({
+      profile,
+      bones: { JAW: jaw },
+      visemeValues: [0.7],
+    }));
+
+    const clip = controller.snippetToClip(
+      'viseme-jaw-inherit',
+      {
+        0: [
+          { time: 0, intensity: 0, inherit: true },
+          { time: 0.16, intensity: 0 },
+        ],
+      },
+      { snippetCategory: 'visemeSnippet', autoVisemeJaw: true }
+    );
+
+    expect(clip).toBeTruthy();
+    const values = getQuaternionTrackValues(clip!, jaw.obj);
+    expect(values[0]).toBeCloseTo(jaw.obj.quaternion.x);
+    expect(values[1]).toBeCloseTo(jaw.obj.quaternion.y);
+    expect(values[2]).toBeCloseTo(jaw.obj.quaternion.z);
+    expect(values[3]).toBeCloseTo(jaw.obj.quaternion.w);
+    expect(values[4]).toBeCloseTo(jaw.baseQuat.x);
+    expect(values[5]).toBeCloseTo(jaw.baseQuat.y);
+    expect(values[6]).toBeCloseTo(jaw.baseQuat.z);
+    expect(values[7]).toBeCloseTo(jaw.baseQuat.w);
+  });
+
+  it('anchors composite bone rotations to the current bone quaternion', () => {
+    const head = makeBone('Head');
+    head.obj.quaternion.copy(new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), 0.25));
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {
+        1: [{ node: 'HEAD', channel: 'ry', scale: 1, maxDegrees: 30 }],
+      },
+      boneNodes: { HEAD: 'Head' },
+      morphToMesh: {},
+      visemeKeys: [],
+      compositeRotations: [
+        {
+          node: 'HEAD',
+          pitch: null,
+          yaw: { aus: [1], axis: 'ry', negative: [], positive: [1] },
+          roll: null,
+        },
+      ],
+    };
+    const controller = new BakedAnimationController(makeHost({
+      profile,
+      bones: { HEAD: head },
+      auValues: { 1: 0.5 },
+    }));
+
+    const clip = controller.snippetToClip('composite-inherit', {
+      1: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const values = getQuaternionTrackValues(clip!, head.obj);
+    expect(values[0]).toBeCloseTo(head.obj.quaternion.x);
+    expect(values[1]).toBeCloseTo(head.obj.quaternion.y);
+    expect(values[2]).toBeCloseTo(head.obj.quaternion.z);
+    expect(values[3]).toBeCloseTo(head.obj.quaternion.w);
+    expect(Math.abs(values[5])).toBeGreaterThan(1e-4);
+  });
+
+  it('anchors bone translation tracks to the current bone position', () => {
+    const head = makeBone('Head');
+    head.obj.position.x = 0.75;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {
+        90: [{ node: 'HEAD', channel: 'tx', scale: 1, maxUnits: 2 }],
+      },
+      boneNodes: { HEAD: 'Head' },
+      morphToMesh: {},
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({
+      profile,
+      bones: { HEAD: head },
+      auValues: { 90: 0.375 },
+    }));
+
+    const clip = controller.snippetToClip('translation-inherit', {
+      90: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const values = getNumberTrackValues(clip!, `${(head.obj as any).uuid}.position[x]`);
+    expect(values).toEqual([0.75, 2]);
+  });
+
+  it('re-resolves inherited starts when a clip is played and replayed', () => {
+    const mesh = makeMorphMesh('Face', { Smile: 0 });
+    mesh.morphTargetInfluences![0] = 0.2;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['Face'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+
+    const clip = controller.snippetToClip('direct-replay-inherit', {
+      Smile: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+    expect(clip).toBeTruthy();
+
+    mesh.morphTargetInfluences![0] = 0.6;
+    const handle = controller.playClip(clip!);
+    expect(handle).toBeTruthy();
+    handle!.setTime?.(0);
+    expect(mesh.morphTargetInfluences![0]).toBeCloseTo(0.6);
+
+    mesh.morphTargetInfluences![0] = 0.8;
+    handle!.play();
+    handle!.setTime?.(0);
+    expect(mesh.morphTargetInfluences![0]).toBeCloseTo(0.8);
+
+    mesh.morphTargetInfluences![0] = 0.9;
+    const nextHandle = controller.playClip(clip!);
+    expect(nextHandle).toBeTruthy();
+    nextHandle!.setTime?.(0);
+    expect(mesh.morphTargetInfluences![0]).toBeCloseTo(0.9);
+  });
+});

--- a/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
+++ b/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
@@ -97,6 +97,16 @@ function getQuaternionTrackValues(clip: NonNullable<ReturnType<BakedAnimationCon
   return Array.from(track!.values as ArrayLike<number>);
 }
 
+async function isPromiseSettled(promise: Promise<void>): Promise<boolean> {
+  let settled = false;
+  promise.then(
+    () => { settled = true; },
+    () => { settled = true; }
+  );
+  await Promise.resolve();
+  return settled;
+}
+
 describe('BakedAnimationController inherited first keyframes', () => {
   it('anchors direct morph curves to the current morph value', () => {
     const mesh = makeMorphMesh('Face', { Smile: 0 });
@@ -121,6 +131,34 @@ describe('BakedAnimationController inherited first keyframes', () => {
     const values = getNumberTrackValues(clip!, `${(mesh as any).uuid}.morphTargetInfluences[0]`);
     expect(values[0]).toBeCloseTo(0.42);
     expect(values[1]).toBeCloseTo(1);
+  });
+
+  it('anchors inherited direct morph curves to each target mesh value', () => {
+    const faceA = makeMorphMesh('FaceA', { Smile: 0 });
+    const faceB = makeMorphMesh('FaceB', { Smile: 0 });
+    faceA.morphTargetInfluences![0] = 0.25;
+    faceB.morphTargetInfluences![0] = 0.75;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['FaceA', 'FaceB'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [faceA, faceB] }));
+
+    const clip = controller.snippetToClip('direct-inherit-per-mesh', {
+      Smile: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const faceAValues = getNumberTrackValues(clip!, `${(faceA as any).uuid}.morphTargetInfluences[0]`);
+    const faceBValues = getNumberTrackValues(clip!, `${(faceB as any).uuid}.morphTargetInfluences[0]`);
+    expect(faceAValues).toEqual([0.25, 1]);
+    expect(faceBValues).toEqual([0.75, 1]);
   });
 
   it('keeps non-inherited direct morph curves absolute', () => {
@@ -172,6 +210,38 @@ describe('BakedAnimationController inherited first keyframes', () => {
     const values = getNumberTrackValues(clip!, `${(mesh as any).uuid}.morphTargetInfluences[0]`);
     expect(values[0]).toBeCloseTo(0.55);
     expect(values[1]).toBeCloseTo(0.8);
+  });
+
+  it('anchors inherited morph-index tracks to each target mesh value', () => {
+    const faceA = makeMorphMesh('FaceA', { Other: 0, Smile: 1 });
+    const faceB = makeMorphMesh('FaceB', { Other: 0, Smile: 1 });
+    faceA.morphTargetInfluences![1] = 0.15;
+    faceB.morphTargetInfluences![1] = 0.65;
+    const profile: Profile = {
+      auToMorphs: {
+        12: { left: [], right: [], center: [1] },
+      },
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['FaceA', 'FaceB'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [faceA, faceB], auValues: { 12: 0.15 } }));
+
+    const clip = controller.snippetToClip('index-inherit-per-mesh', {
+      12: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 0.9 },
+      ],
+    });
+
+    expect(clip).toBeTruthy();
+    const faceAValues = getNumberTrackValues(clip!, `${(faceA as any).uuid}.morphTargetInfluences[1]`);
+    const faceBValues = getNumberTrackValues(clip!, `${(faceB as any).uuid}.morphTargetInfluences[1]`);
+    expect(faceAValues[0]).toBeCloseTo(0.15);
+    expect(faceAValues[1]).toBeCloseTo(0.9);
+    expect(faceBValues[0]).toBeCloseTo(0.65);
+    expect(faceBValues[1]).toBeCloseTo(0.9);
   });
 
   it('anchors auto viseme jaw tracks to the current jaw quaternion', () => {
@@ -324,5 +394,37 @@ describe('BakedAnimationController inherited first keyframes', () => {
     expect(nextHandle).toBeTruthy();
     nextHandle!.setTime?.(0);
     expect(mesh.morphTargetInfluences![0]).toBeCloseTo(0.9);
+  });
+
+  it('keeps the finished promise pending while replaying an inherited handle', async () => {
+    const mesh = makeMorphMesh('Face', { Smile: 0 });
+    mesh.morphTargetInfluences![0] = 0.2;
+    const profile: Profile = {
+      auToMorphs: {},
+      auToBones: {},
+      boneNodes: {},
+      morphToMesh: { face: ['Face'] },
+      visemeKeys: [],
+    };
+    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+
+    const clip = controller.snippetToClip('direct-replay-promise-inherit', {
+      Smile: [
+        { time: 0, intensity: 0, inherit: true },
+        { time: 0.5, intensity: 1 },
+      ],
+    });
+    expect(clip).toBeTruthy();
+
+    const handle = controller.playClip(clip!, { loopMode: 'once' });
+    expect(handle).toBeTruthy();
+    expect(await isPromiseSettled(handle!.finished)).toBe(false);
+
+    mesh.morphTargetInfluences![0] = 0.8;
+    handle!.play();
+    expect(await isPromiseSettled(handle!.finished)).toBe(false);
+
+    controller.update(0.5);
+    expect(await isPromiseSettled(handle!.finished)).toBe(true);
   });
 });

--- a/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
+++ b/src/engines/three/AnimationThree.inheritedKeyframes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D, Quaternion, Vector3 } from 'three';
 import type { Profile } from '../../mappings/types';
 import type { ResolvedBones } from './types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 function makeMorphMesh(name: string, dictionary: Record<string, number>): Mesh {
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
@@ -36,7 +36,7 @@ function makeHost({
   bones?: ResolvedBones;
   auValues?: Record<number, number>;
   visemeValues?: number[];
-}): BakedAnimationHost {
+}): AnimationControllerHost {
   const model = new Object3D();
   for (const mesh of meshes) model.add(mesh);
   for (const bone of Object.values(bones)) {
@@ -85,13 +85,13 @@ function makeHost({
   };
 }
 
-function getNumberTrackValues(clip: NonNullable<ReturnType<BakedAnimationController['snippetToClip']>>, trackNamePart: string): number[] {
+function getNumberTrackValues(clip: NonNullable<ReturnType<AnimationController['snippetToClip']>>, trackNamePart: string): number[] {
   const track = clip.tracks.find((entry) => entry.name.includes(trackNamePart));
   expect(track).toBeTruthy();
   return Array.from(track!.values as ArrayLike<number>);
 }
 
-function getQuaternionTrackValues(clip: NonNullable<ReturnType<BakedAnimationController['snippetToClip']>>, obj: Object3D): number[] {
+function getQuaternionTrackValues(clip: NonNullable<ReturnType<AnimationController['snippetToClip']>>, obj: Object3D): number[] {
   const track = clip.tracks.find((entry) => entry.name === `${(obj as any).uuid}.quaternion`);
   expect(track).toBeTruthy();
   return Array.from(track!.values as ArrayLike<number>);
@@ -107,7 +107,7 @@ async function isPromiseSettled(promise: Promise<void>): Promise<boolean> {
   return settled;
 }
 
-describe('BakedAnimationController inherited first keyframes', () => {
+describe('AnimationController inherited first keyframes', () => {
   it('anchors direct morph curves to the current morph value', () => {
     const mesh = makeMorphMesh('Face', { Smile: 0 });
     mesh.morphTargetInfluences![0] = 0.42;
@@ -118,7 +118,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['Face'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [mesh] }));
 
     const clip = controller.snippetToClip('direct-inherit', {
       Smile: [
@@ -145,7 +145,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['FaceA', 'FaceB'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [faceA, faceB] }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [faceA, faceB] }));
 
     const clip = controller.snippetToClip('direct-inherit-per-mesh', {
       Smile: [
@@ -171,7 +171,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['Face'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [mesh] }));
 
     const clip = controller.snippetToClip('direct-absolute', {
       Smile: [
@@ -197,7 +197,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['Face'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh], auValues: { 12: 0.55 } }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [mesh], auValues: { 12: 0.55 } }));
 
     const clip = controller.snippetToClip('au-morph-inherit', {
       12: [
@@ -226,7 +226,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['FaceA', 'FaceB'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [faceA, faceB], auValues: { 12: 0.15 } }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [faceA, faceB], auValues: { 12: 0.15 } }));
 
     const clip = controller.snippetToClip('index-inherit-per-mesh', {
       12: [
@@ -257,7 +257,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       visemeKeys: ['AA'],
       visemeJawAmounts: [1],
     };
-    const controller = new BakedAnimationController(makeHost({
+    const controller = new AnimationController(makeHost({
       profile,
       bones: { JAW: jaw },
       visemeValues: [0.7],
@@ -306,7 +306,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
         },
       ],
     };
-    const controller = new BakedAnimationController(makeHost({
+    const controller = new AnimationController(makeHost({
       profile,
       bones: { HEAD: head },
       auValues: { 1: 0.5 },
@@ -340,7 +340,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: {},
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({
+    const controller = new AnimationController(makeHost({
       profile,
       bones: { HEAD: head },
       auValues: { 90: 0.375 },
@@ -368,7 +368,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['Face'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [mesh] }));
 
     const clip = controller.snippetToClip('direct-replay-inherit', {
       Smile: [
@@ -406,7 +406,7 @@ describe('BakedAnimationController inherited first keyframes', () => {
       morphToMesh: { face: ['Face'] },
       visemeKeys: [],
     };
-    const controller = new BakedAnimationController(makeHost({ profile, meshes: [mesh] }));
+    const controller = new AnimationController(makeHost({ profile, meshes: [mesh] }));
 
     const clip = controller.snippetToClip('direct-replay-promise-inherit', {
       Smile: [

--- a/src/engines/three/AnimationThree.meshSelection.test.ts
+++ b/src/engines/three/AnimationThree.meshSelection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { BufferGeometry, Mesh, MeshBasicMaterial, Object3D } from 'three';
 import type { Profile } from '../../mappings/types';
 import { getMeshNamesForAUProfile, getMeshNamesForVisemeProfile } from '../../mappings/visemeSystem';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 function makeMorphMesh(name: string, dictionary: Record<string, number>): Mesh {
   const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
@@ -21,7 +21,7 @@ function getMeshNamesForViseme(profile: Profile): string[] {
   return getMeshNamesForVisemeProfile(profile);
 }
 
-function makeHost(profile: Profile, meshes: Mesh[]): BakedAnimationHost {
+function makeHost(profile: Profile, meshes: Mesh[]): AnimationControllerHost {
   const meshMap = new Map(meshes.map((mesh) => [mesh.name, mesh]));
   return {
     getModel: () => new Object3D(),
@@ -38,7 +38,7 @@ function makeHost(profile: Profile, meshes: Mesh[]): BakedAnimationHost {
   };
 }
 
-describe('BakedAnimationController mesh selection', () => {
+describe('AnimationController mesh selection', () => {
   it('routes AU clip tracks using AU mesh mapping (eye AUs stay on eye meshes)', () => {
     const faceMesh = makeMorphMesh('FaceMesh', { Eye_Look_Left: 0 });
     const eyeMesh = makeMorphMesh('EyeMesh', { Eye_Look_Left: 0 });
@@ -58,7 +58,7 @@ describe('BakedAnimationController mesh selection', () => {
     };
 
     const host = makeHost(profile, [faceMesh, eyeMesh]);
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const clip = controller.snippetToClip(
       'eye-au-routing',
       { '61': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] }
@@ -85,7 +85,7 @@ describe('BakedAnimationController mesh selection', () => {
     };
 
     const host = makeHost(profile, [faceMesh, accessoryMesh]);
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const clip = controller.snippetToClip(
       'no-all-mesh-fallback',
       { '1': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] }
@@ -108,7 +108,7 @@ describe('BakedAnimationController mesh selection', () => {
     };
 
     const host = makeHost(profile, [faceMesh, visemeMesh]);
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const clip = controller.snippetToClip(
       'viseme-routing',
       { '0': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] },
@@ -143,7 +143,7 @@ describe('BakedAnimationController mesh selection', () => {
     };
 
     const host = makeHost(profile, [visemeMesh]);
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const clip = controller.snippetToClip(
       'viseme-bindings',
       { '0': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] },
@@ -172,7 +172,7 @@ describe('BakedAnimationController mesh selection', () => {
     };
 
     const host = makeHost(profile, [faceMesh]);
-    const controller = new BakedAnimationController(host);
+    const controller = new AnimationController(host);
     const clip = controller.snippetToClip(
       'viseme-empty-routing',
       { '0': [{ time: 0, intensity: 0 }, { time: 1, intensity: 1 }] },

--- a/src/engines/three/AnimationThree.playbackState.test.ts
+++ b/src/engines/three/AnimationThree.playbackState.test.ts
@@ -11,10 +11,10 @@ import {
   Vector3,
 } from 'three';
 import type { Profile } from '../../mappings/types';
-import { BakedAnimationController, type BakedAnimationHost } from './AnimationThree';
+import { AnimationController, type AnimationControllerHost } from './AnimationThree';
 
 function makeHost(options: { includeHeadBone?: boolean; includeCamera?: boolean } = {}): {
-  controller: BakedAnimationController;
+  controller: AnimationController;
   model: Object3D;
   mesh: Mesh;
   head: Object3D | null;
@@ -59,7 +59,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeCamera?: boolean 
     visemeKeys: [],
   };
 
-  const host: BakedAnimationHost = {
+  const host: AnimationControllerHost = {
     getModel: () => model,
     getMeshes: () => [mesh],
     getMeshByName: (name: string) => (name === 'FaceMesh' ? mesh : undefined),
@@ -71,7 +71,7 @@ function makeHost(options: { includeHeadBone?: boolean; includeCamera?: boolean 
     isMixedAU: () => false,
   };
 
-  return { controller: new BakedAnimationController(host), model, mesh, head, camera };
+  return { controller: new AnimationController(host), model, mesh, head, camera };
 }
 
 function makeTransformClip(model: Object3D, name: string): AnimationClip {
@@ -117,7 +117,7 @@ function makeSceneClip(camera: Object3D, name: string): AnimationClip {
   ]);
 }
 
-describe('BakedAnimationController playback state normalization', () => {
+describe('AnimationController playback state normalization', () => {
   it('normalizes baked clip options into the shared animation state surface', () => {
     const { controller } = makeHost();
     controller.loadAnimationClips([makeMorphClip('Idle')]);
@@ -165,7 +165,7 @@ describe('BakedAnimationController playback state normalization', () => {
     });
   });
 
-  it('partitions mixed baked clips into face and body runtime channels', () => {
+  it('partitions mixed baked clips into face and body mixer channels', () => {
     const { controller, model, head } = makeHost({ includeHeadBone: true });
     expect(head).toBeTruthy();
     controller.loadAnimationClips([makeMixedClip(model, head!, 'HeadAndBody')]);

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -41,6 +41,7 @@ import type {
   BakedClipChannel,
   BakedClipChannelInfo,
   AnimationEasing,
+  CurvePoint,
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
 import type { Profile } from '../../mappings/types';
@@ -202,6 +203,12 @@ export interface BakedAnimationHost {
   getMeshByName: (name: string) => Mesh | undefined;
   getMeshNamesForAU?: (auId: number) => string[];
   getMeshNamesForViseme?: () => string[];
+  getCurrentAUValue?: (auId: number) => number;
+  getCurrentVisemeValue?: (visemeIndex: number) => number;
+  getCurrentMorphValue?: (morphKey: string, meshNames?: string[]) => number;
+  getCurrentMorphIndexValue?: (morphIndex: number, meshNames?: string[]) => number;
+  getCurrentBoneQuaternion?: (nodeKey: string) => Quaternion | null;
+  getCurrentBonePositionValue?: (nodeKey: string, axis: 'x' | 'y' | 'z') => number | null;
   getBones: () => ResolvedBones;
   getConfig: () => Profile;
   getCompositeRotations: () => CompositeRotation[];
@@ -222,6 +229,8 @@ const CLIP_EVENT_EPSILON = 1e-4;
 type ClipEventMetadata = {
   keyframeTimes: number[];
 };
+
+type ScalarKeyframe = Pick<CurvePoint, 'time' | 'intensity' | 'inherit'>;
 
 type ClipMonitor = {
   action: AnimationAction;
@@ -264,6 +273,13 @@ type BakedActionGroup = {
   resolveFinished: () => void;
 };
 
+type DynamicClipSource = {
+  clipName: string;
+  curves: CurvesMap;
+  options?: ClipOptions;
+  hasInheritedStart: boolean;
+};
+
 const ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX = '__loom3_additive_delta';
 
 export class BakedAnimationController {
@@ -288,6 +304,7 @@ export class BakedAnimationController {
   private actionIds = new WeakMap<AnimationAction, string>();
   private actionIdToClip = new Map<string, string>();
   private clipMonitors = new Map<string, ClipMonitor>();
+  private dynamicClipSources = new WeakMap<AnimationClip, DynamicClipSource>();
 
   constructor(host: BakedAnimationHost) {
     this.host = host;
@@ -530,6 +547,18 @@ export class BakedAnimationController {
       ? userData[CLIP_EVENT_METADATA_KEY].keyframeTimes.filter((time: unknown): time is number => Number.isFinite(time as number))
       : [];
     return { keyframeTimes };
+  }
+
+  private curvesHaveInheritedStart(curves: CurvesMap): boolean {
+    return Object.values(curves).some((curve) => !!curve?.[0]?.inherit);
+  }
+
+  private resolveInheritedClipForPlayback(clip: AnimationClip): AnimationClip {
+    const source = this.dynamicClipSources.get(clip);
+    if (!source?.hasInheritedStart) {
+      return clip;
+    }
+    return this.snippetToClip(source.clipName, source.curves, source.options) ?? clip;
   }
 
   private getKeyframeIndex(times: number[], currentTime: number) {
@@ -1715,27 +1744,27 @@ export class BakedAnimationController {
       return !Number.isNaN(num) && num >= 0 && num < visemeSlotCount;
     };
 
-    const sampleAt = (arr: Array<{ time: number; intensity: number }>, t: number) => {
-      if (!arr.length) return 0;
-      if (t <= arr[0].time) return arr[0].intensity;
-      if (t >= arr[arr.length - 1].time) return arr[arr.length - 1].intensity;
-      for (let i = 0; i < arr.length - 1; i++) {
-        const a = arr[i];
-        const b = arr[i + 1];
-        if (t >= a.time && t <= b.time) {
-          const dt = Math.max(1e-6, b.time - a.time);
-          const p = (t - a.time) / dt;
-          return a.intensity + (b.intensity - a.intensity) * p;
-        }
-      }
-      return 0;
-    };
-
+    const hasInheritedStart = (arr: ScalarKeyframe[] | undefined) => !!arr?.[0]?.inherit;
     const clampIntensity = (v: number) => Math.max(0, Math.min(2, v));
     const sampleCurve = (curveId: string, t: number) => {
       const arr = curves[curveId];
       if (!arr) return 0;
-      return clampIntensity(sampleAt(arr, t) * intensityScale);
+      let inheritedStartValue: number | undefined;
+      if (hasInheritedStart(arr)) {
+        if (isVisemeIndex(curveId)) {
+          inheritedStartValue = this.host.getCurrentVisemeValue?.(Number(curveId));
+        } else if (isNumericAU(curveId)) {
+          inheritedStartValue = this.host.getCurrentAUValue?.(Number(curveId));
+        }
+      }
+      return clampIntensity(
+        this.sampleFinalKeyframeValue(
+          arr,
+          t,
+          (intensity) => intensity * intensityScale,
+          inheritedStartValue === undefined ? undefined : clampIntensity(inheritedStartValue)
+        )
+      );
     };
 
     const keyframeTimes = (() => {
@@ -1827,8 +1856,19 @@ export class BakedAnimationController {
       if (jawEntry) {
         // Sample all viseme curves at each keyframe time and compute weighted jaw amount
         const jawValues: number[] = [];
+        const inheritedJawStart = keyframeTimes.length > 0
+          && Array.from({ length: visemeSlotCount }, (_, index) => curves[String(index)])
+            .some((curve) => hasInheritedStart(curve));
+        const currentJawQ = inheritedJawStart
+          ? this.host.getCurrentBoneQuaternion?.('JAW') ?? null
+          : null;
 
-        for (const t of keyframeTimes) {
+        for (let timeIndex = 0; timeIndex < keyframeTimes.length; timeIndex += 1) {
+          const t = keyframeTimes[timeIndex];
+          if (timeIndex === 0 && currentJawQ) {
+            jawValues.push(currentJawQ.x, currentJawQ.y, currentJawQ.z, currentJawQ.w);
+            continue;
+          }
           let jawAmount = 0;
 
           // Sum contributions from all active visemes at time t
@@ -1836,7 +1876,7 @@ export class BakedAnimationController {
             const visemeCurve = curves[String(visemeIdx)];
             if (!visemeCurve) continue;
 
-            const visemeValue = clampIntensity(sampleAt(visemeCurve, t) * intensityScale);
+            const visemeValue = sampleCurve(String(visemeIdx), t);
             if (visemeValue > 0 && visemeIdx < visemeJawAmounts.length) {
               // Take max jaw amount across all active visemes (like transitionViseme)
               const visemeJaw = visemeJawAmounts[visemeIdx] * visemeValue * jawScale;
@@ -1929,17 +1969,30 @@ export class BakedAnimationController {
           continue;
         }
 
-        const hasRelevantAU = [composite.pitch, composite.yaw, composite.roll]
+        const relevantAUs = new Set<number>();
+        [composite.pitch, composite.yaw, composite.roll]
           .filter(Boolean)
-          .some((axisConfig) => axisConfig!.aus.some((auId) => hasCurveAU.has(auId)));
+          .forEach((axisConfig) => {
+            axisConfig!.aus.forEach((auId) => {
+              if (hasCurveAU.has(auId)) relevantAUs.add(auId);
+            });
+          });
 
-        if (!hasRelevantAU) {
+        if (relevantAUs.size === 0) {
           continue;
         }
 
         const values: number[] = [];
+        const currentBoneQ = Array.from(relevantAUs).some((auId) => hasInheritedStart(curves[String(auId)]))
+          ? this.host.getCurrentBoneQuaternion?.(nodeKey) ?? null
+          : null;
 
-        for (const t of keyframeTimes) {
+        for (let timeIndex = 0; timeIndex < keyframeTimes.length; timeIndex += 1) {
+          const t = keyframeTimes[timeIndex];
+          if (timeIndex === 0 && currentBoneQ) {
+            values.push(currentBoneQ.x, currentBoneQ.y, currentBoneQ.z, currentBoneQ.w);
+            continue;
+          }
           const compositeQ = new Quaternion().copy(entry.baseQuat);
 
           const applyAxis = (
@@ -1983,12 +2036,23 @@ export class BakedAnimationController {
 
           const axisIndex: 'x' | 'y' | 'z' = binding.channel === 'tx' ? 'x' : binding.channel === 'ty' ? 'y' : 'z';
           const basePos = entry.basePos[axisIndex];
+          const inheritedStartValue = curve[0]?.inherit
+            ? this.host.getCurrentBonePositionValue?.(binding.node, axisIndex) ?? entry.obj.position[axisIndex]
+            : undefined;
           const values: number[] = [];
 
           for (const t of keyframeTimes) {
-            const v = sampleCurve(curveId, t);
-            const delta = v * binding.maxUnits * binding.scale;
-            values.push(basePos + delta);
+            values.push(
+              this.sampleFinalKeyframeValue(
+                curve,
+                t,
+                (intensity) => {
+                  const v = clampIntensity(intensity * intensityScale);
+                  return basePos + (v * binding.maxUnits! * binding.scale);
+                },
+                inheritedStartValue
+              )
+            );
           }
 
           const trackName = `${entry.obj.uuid}.position[${axisIndex}]`;
@@ -2004,6 +2068,12 @@ export class BakedAnimationController {
 
     const clip = new AnimationClip(clipName, maxTime, tracks);
     this.setClipEventMetadata(clip, { keyframeTimes });
+    this.dynamicClipSources.set(clip, {
+      clipName,
+      curves,
+      options,
+      hasInheritedStart: this.curvesHaveInheritedStart(curves),
+    });
     console.log(`[Loom3] snippetToClip: Created clip "${clipName}" with ${tracks.length} tracks, duration ${maxTime.toFixed(2)}s`);
 
     return clip;
@@ -2016,6 +2086,8 @@ export class BakedAnimationController {
       console.warn('[Loom3] playClip: No model loaded, cannot create mixer');
       return null;
     }
+    const hasInheritedStart = !!this.dynamicClipSources.get(clip)?.hasInheritedStart;
+    clip = this.resolveInheritedClipForPlayback(clip);
 
     const playbackState = this.mergePlaybackOptions(
       this.getPlaybackStateSnapshot(clip.name, {
@@ -2026,12 +2098,24 @@ export class BakedAnimationController {
     );
     const startTime = this.resolveStartTime(clip.duration, playbackState, options?.startTime);
 
-    let action = this.clipActions.get(clip.name);
-    let actionId = this.getActionId(action);
-    if (action && !actionId) {
-      actionId = this.setActionId(action, clip.name);
+    let action: AnimationAction;
+    let actionId: string;
+    let existingAction = this.clipActions.get(clip.name);
+    if (existingAction && hasInheritedStart && existingAction.getClip() !== clip) {
+      const previousClip = existingAction.getClip();
+      const previousActionId = this.getActionId(existingAction);
+      try { existingAction.stop(); } catch {}
+      try { mixer.uncacheAction(previousClip); } catch {}
+      try { mixer.uncacheClip(previousClip); } catch {}
+      if (previousActionId) this.cleanupClipMonitor(previousActionId);
+      this.clipActions.delete(clip.name);
+      this.animationActions.delete(clip.name);
+      existingAction = undefined;
     }
-    if (!action) {
+    if (existingAction) {
+      action = existingAction;
+      actionId = this.getActionId(action) ?? this.setActionId(action, clip.name);
+    } else {
       action = mixer.clipAction(clip);
       actionId = this.setActionId(action, clip.name);
     }
@@ -2042,35 +2126,39 @@ export class BakedAnimationController {
     }
     this.applyPlaybackState(action, playbackState);
 
-    if (actionId) {
-      this.cleanupClipMonitor(actionId);
-    }
+    this.cleanupClipMonitor(actionId);
 
     let resolveFinished!: () => void;
     const finishedPromise = new Promise<void>((resolve) => {
       resolveFinished = resolve;
     });
-    const keyframeTimes = this.getClipEventMetadata(clip).keyframeTimes;
-    const initialDirection: 1 | -1 = playbackState.reverse ? -1 : 1;
-    const monitor: ClipMonitor = {
-      action,
-      actionId: actionId!,
-      clip,
-      clipName: clip.name,
-      duration: clip.duration,
-      keyframeTimes,
-      listeners: new Set<ClipEventListener>(),
-      initialDirection,
-      direction: initialDirection,
-      iteration: 0,
-      lastTime: Math.max(0, Math.min(clip.duration, action.time)),
-      lastKeyframeIndex: this.getKeyframeIndex(keyframeTimes, action.time),
-      loopMode: playbackState.loopMode,
-      finishedPending: false,
-      cleanedUp: false,
-      resolveFinished,
+    const createMonitor = (
+      listeners = new Set<ClipEventListener>(),
+      state = this.playbackState.get(clip.name) ?? playbackState
+    ): ClipMonitor => {
+      const keyframeTimes = this.getClipEventMetadata(clip).keyframeTimes;
+      const initialDirection: 1 | -1 = state.reverse ? -1 : 1;
+      return {
+        action,
+        actionId,
+        clip,
+        clipName: clip.name,
+        duration: clip.duration,
+        keyframeTimes,
+        listeners,
+        initialDirection,
+        direction: initialDirection,
+        iteration: 0,
+        lastTime: Math.max(0, Math.min(clip.duration, action.time)),
+        lastKeyframeIndex: this.getKeyframeIndex(keyframeTimes, action.time),
+        loopMode: state.loopMode,
+        finishedPending: false,
+        cleanedUp: false,
+        resolveFinished,
+      };
     };
-    this.clipMonitors.set(actionId!, monitor);
+    let monitor = createMonitor();
+    this.clipMonitors.set(actionId, monitor);
 
     action.reset();
     action.time = startTime;
@@ -2087,6 +2175,27 @@ export class BakedAnimationController {
       actionId,
 
       play: () => {
+        const source = this.dynamicClipSources.get(clip);
+        if (source?.hasInheritedStart) {
+          const listeners = new Set(monitor.listeners);
+          const nextClip = this.snippetToClip(source.clipName, source.curves, source.options);
+          if (nextClip) {
+            try { action.stop(); } catch {}
+            try { mixer.uncacheAction(clip); } catch {}
+            try { mixer.uncacheClip(clip); } catch {}
+            this.cleanupClipMonitor(actionId);
+            clip = nextClip;
+            action = mixer.clipAction(clip);
+            actionId = this.setActionId(action, clip.name);
+            handle.actionId = actionId;
+            const nextPlaybackState = this.playbackState.get(clip.name) ?? playbackState;
+            this.applyPlaybackState(action, nextPlaybackState);
+            monitor = createMonitor(listeners, nextPlaybackState);
+            this.clipMonitors.set(actionId, monitor);
+            this.clipActions.set(clip.name, action);
+            this.animationActions.set(clip.name, action);
+          }
+        }
         action.reset();
         action.time = this.resolveStartTime(
           clip.duration,
@@ -2108,7 +2217,7 @@ export class BakedAnimationController {
         this.animationActions.delete(clip.name);
         this.animationFinishedCallbacks.delete(clip.name);
         this.playbackState.delete(clip.name);
-        this.cleanupClipMonitor(actionId!);
+        this.cleanupClipMonitor(actionId);
       },
 
       pause: () => {
@@ -2304,7 +2413,7 @@ export class BakedAnimationController {
   private addMorphTracks(
     tracks: Array<NumberKeyframeTrack | QuaternionKeyframeTrack>,
     morphKey: string,
-    keyframes: Array<{ time: number; intensity: number }>,
+    keyframes: ScalarKeyframe[],
     intensityScale: number,
     meshNames?: string[]
   ): void {
@@ -2317,16 +2426,33 @@ export class BakedAnimationController {
 
     const addTrackForMesh = (mesh: Mesh) => {
       const dict = mesh.morphTargetDictionary;
-      if (!dict || dict[morphKey] === undefined) return;
+      const infl = mesh.morphTargetInfluences;
+      if (!dict || !infl || dict[morphKey] === undefined) return;
 
       const morphIndex = dict[morphKey];
+      const inheritedStartValue = keyframes[0]?.inherit
+        ? this.host.getCurrentMorphValue?.(morphKey, meshNames) ?? infl[morphIndex] ?? 0
+        : undefined;
 
       const times: number[] = [];
       const values: number[] = [];
 
       for (const kf of keyframes) {
         times.push(kf.time);
-        values.push(Math.max(0, Math.min(2, kf.intensity * intensityScale)));
+        values.push(
+          Math.max(
+            0,
+            Math.min(
+              2,
+              this.sampleFinalKeyframeValue(
+                keyframes,
+                kf.time,
+                (intensity) => intensity * intensityScale,
+                inheritedStartValue
+              )
+            )
+          )
+        );
       }
 
       const trackName = `${mesh.uuid}.morphTargetInfluences[${morphIndex}]`;
@@ -2343,7 +2469,7 @@ export class BakedAnimationController {
   private addMorphIndexTracks(
     tracks: Array<NumberKeyframeTrack | QuaternionKeyframeTrack>,
     morphIndex: number,
-    keyframes: Array<{ time: number; intensity: number }>,
+    keyframes: ScalarKeyframe[],
     intensityScale: number,
     meshNames?: string[]
   ): void {
@@ -2358,13 +2484,29 @@ export class BakedAnimationController {
     const addTrackForMesh = (mesh: Mesh) => {
       const infl = mesh.morphTargetInfluences;
       if (!infl || morphIndex < 0 || morphIndex >= infl.length) return;
+      const inheritedStartValue = keyframes[0]?.inherit
+        ? this.host.getCurrentMorphIndexValue?.(morphIndex, meshNames) ?? infl[morphIndex] ?? 0
+        : undefined;
 
       const times: number[] = [];
       const values: number[] = [];
 
       for (const kf of keyframes) {
         times.push(kf.time);
-        values.push(Math.max(0, Math.min(2, kf.intensity * intensityScale)));
+        values.push(
+          Math.max(
+            0,
+            Math.min(
+              2,
+              this.sampleFinalKeyframeValue(
+                keyframes,
+                kf.time,
+                (intensity) => intensity * intensityScale,
+                inheritedStartValue
+              )
+            )
+          )
+        );
       }
 
       const trackName = `${mesh.uuid}.morphTargetInfluences[${morphIndex}]`;
@@ -2376,6 +2518,34 @@ export class BakedAnimationController {
     for (const mesh of targetMeshes) {
       addTrackForMesh(mesh);
     }
+  }
+
+  private sampleFinalKeyframeValue(
+    keyframes: ScalarKeyframe[],
+    t: number,
+    toFinalValue: (intensity: number) => number,
+    inheritedStartValue?: number
+  ): number {
+    if (!keyframes.length) return 0;
+    const firstValue = inheritedStartValue ?? toFinalValue(keyframes[0].intensity);
+    if (t <= keyframes[0].time) return firstValue;
+    if (t >= keyframes[keyframes.length - 1].time) {
+      return toFinalValue(keyframes[keyframes.length - 1].intensity);
+    }
+
+    for (let i = 0; i < keyframes.length - 1; i += 1) {
+      const a = keyframes[i];
+      const b = keyframes[i + 1];
+      if (t >= a.time && t <= b.time) {
+        const dt = Math.max(1e-6, b.time - a.time);
+        const p = (t - a.time) / dt;
+        const aValue = i === 0 ? firstValue : toFinalValue(a.intensity);
+        const bValue = toFinalValue(b.intensity);
+        return aValue + (bValue - aValue) * p;
+      }
+    }
+
+    return 0;
   }
 
   private ensureMixer(): AnimationMixer | null {

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -645,12 +645,15 @@ export class BakedAnimationController {
     }
   }
 
-  private cleanupClipMonitor(actionId: string) {
+  private cleanupClipMonitor(actionId: string, options: { resolveFinished?: boolean } = {}) {
     const monitor = this.clipMonitors.get(actionId);
     if (!monitor || monitor.cleanedUp) return;
+    const { resolveFinished = true } = options;
     monitor.cleanedUp = true;
     try { monitor.action.paused = true; } catch {}
-    monitor.resolveFinished();
+    if (resolveFinished) {
+      monitor.resolveFinished();
+    }
     monitor.listeners.clear();
     this.clipMonitors.delete(actionId);
     this.actionIdToClip.delete(actionId);
@@ -2183,7 +2186,7 @@ export class BakedAnimationController {
             try { action.stop(); } catch {}
             try { mixer.uncacheAction(clip); } catch {}
             try { mixer.uncacheClip(clip); } catch {}
-            this.cleanupClipMonitor(actionId);
+            this.cleanupClipMonitor(actionId, { resolveFinished: false });
             clip = nextClip;
             action = mixer.clipAction(clip);
             actionId = this.setActionId(action, clip.name);
@@ -2430,9 +2433,7 @@ export class BakedAnimationController {
       if (!dict || !infl || dict[morphKey] === undefined) return;
 
       const morphIndex = dict[morphKey];
-      const inheritedStartValue = keyframes[0]?.inherit
-        ? this.host.getCurrentMorphValue?.(morphKey, meshNames) ?? infl[morphIndex] ?? 0
-        : undefined;
+      const inheritedStartValue = keyframes[0]?.inherit ? infl[morphIndex] ?? 0 : undefined;
 
       const times: number[] = [];
       const values: number[] = [];
@@ -2484,9 +2485,7 @@ export class BakedAnimationController {
     const addTrackForMesh = (mesh: Mesh) => {
       const infl = mesh.morphTargetInfluences;
       if (!infl || morphIndex < 0 || morphIndex >= infl.length) return;
-      const inheritedStartValue = keyframes[0]?.inherit
-        ? this.host.getCurrentMorphIndexValue?.(morphIndex, meshNames) ?? infl[morphIndex] ?? 0
-        : undefined;
+      const inheritedStartValue = keyframes[0]?.inherit ? infl[morphIndex] ?? 0 : undefined;
 
       const times: number[] = [];
       const values: number[] = [];

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -197,7 +197,7 @@ export class AnimationThree {
   }
 }
 
-export interface BakedAnimationHost {
+export interface AnimationControllerHost {
   getModel: () => Object3D | null;
   getMeshes: () => Mesh[];
   getMeshByName: (name: string) => Mesh | undefined;
@@ -217,6 +217,9 @@ export interface BakedAnimationHost {
   isMixedAU: (auId: number) => boolean;
   reapplyProceduralState?: () => void;
 }
+
+/** @deprecated Use AnimationControllerHost. */
+export type BakedAnimationHost = AnimationControllerHost;
 
 // Lightweight unique id for mixer actions/handles
 const makeActionId = () => `act_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
@@ -280,10 +283,10 @@ type DynamicClipSource = {
   hasInheritedStart: boolean;
 };
 
-const ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX = '__loom3_additive_delta';
+const ADDITIVE_BAKED_MIXER_CLIP_SUFFIX = '__loom3_additive_delta';
 
-export class BakedAnimationController {
-  private host: BakedAnimationHost;
+export class AnimationController {
+  private host: AnimationControllerHost;
   // Clip-backed snippets need a later mixer pass so they can override baked additive tracks.
   private animationMixer: AnimationMixer | null = null;
   private clipAnimationMixer: AnimationMixer | null = null;
@@ -291,10 +294,10 @@ export class BakedAnimationController {
   private clipMixerFinishedListenerAttached = false;
   private animationClips: AnimationClip[] = [];
   private bakedSourceClips = new Map<string, PartitionedBakedClip>();
-  private bakedRuntimeActions = new Map<string, AnimationAction>();
-  private bakedAdditiveRuntimeClips = new Map<string, AnimationClip>();
+  private bakedMixerActions = new Map<string, AnimationAction>();
+  private bakedAdditiveMixerClips = new Map<string, AnimationClip>();
   private bakedActionGroups = new Map<string, BakedActionGroup>();
-  private bakedRuntimeClipToSource = new Map<string, { sourceClipName: string; channel: BakedClipChannel }>();
+  private bakedMixerClipToSource = new Map<string, { sourceClipName: string; channel: BakedClipChannel }>();
   private animationActions = new Map<string, AnimationAction>();
   private animationFinishedCallbacks = new Map<string, () => void>();
   private clipActions = new Map<string, AnimationAction>();
@@ -306,7 +309,7 @@ export class BakedAnimationController {
   private clipMonitors = new Map<string, ClipMonitor>();
   private dynamicClipSources = new WeakMap<AnimationClip, DynamicClipSource>();
 
-  constructor(host: BakedAnimationHost) {
+  constructor(host: AnimationControllerHost) {
     this.host = host;
   }
 
@@ -357,27 +360,27 @@ export class BakedAnimationController {
     } catch {}
   }
 
-  private releaseBakedRuntimeAction(runtimeClipName: string): void {
-    const action = this.bakedRuntimeActions.get(runtimeClipName);
+  private releaseBakedMixerAction(mixerClipName: string): void {
+    const action = this.bakedMixerActions.get(mixerClipName);
     if (!action) return;
     try {
       action.stop();
     } catch {}
     this.uncacheAction(action);
     this.clearActionId(action);
-    this.bakedRuntimeActions.delete(runtimeClipName);
+    this.bakedMixerActions.delete(mixerClipName);
   }
 
-  private clearBakedAdditiveRuntimeClip(runtimeClipName: string): void {
-    const clip = this.bakedAdditiveRuntimeClips.get(runtimeClipName);
+  private clearBakedAdditiveMixerClip(mixerClipName: string): void {
+    const clip = this.bakedAdditiveMixerClips.get(mixerClipName);
     if (!clip) return;
     this.uncacheClip(clip);
-    this.bakedAdditiveRuntimeClips.delete(runtimeClipName);
+    this.bakedAdditiveMixerClips.delete(mixerClipName);
   }
 
-  private clearAllBakedAdditiveRuntimeClips(): void {
-    for (const runtimeClipName of Array.from(this.bakedAdditiveRuntimeClips.keys())) {
-      this.clearBakedAdditiveRuntimeClip(runtimeClipName);
+  private clearAllBakedAdditiveMixerClips(): void {
+    for (const mixerClipName of Array.from(this.bakedAdditiveMixerClips.keys())) {
+      this.clearBakedAdditiveMixerClip(mixerClipName);
     }
   }
 
@@ -489,7 +492,7 @@ export class BakedAnimationController {
     return this.createFirstFrameReferenceTrack(track);
   }
 
-  private createAdditiveRuntimeClip(runtimeClip: AnimationClip): AnimationClip | null {
+  private createAdditiveMixerClip(mixerClip: AnimationClip): AnimationClip | null {
     const model = this.host.getModel();
     if (!model) {
       return null;
@@ -497,7 +500,7 @@ export class BakedAnimationController {
 
     const additiveTracks: KeyframeTrack[] = [];
     const referenceTracks: KeyframeTrack[] = [];
-    for (const track of runtimeClip.tracks) {
+    for (const track of mixerClip.tracks) {
       const referenceTrack = this.createAdditiveReferenceTrack(track, model);
       if (!referenceTrack) {
         continue;
@@ -507,13 +510,13 @@ export class BakedAnimationController {
     }
 
     const additiveClip = new AnimationClip(
-      `${runtimeClip.name}${ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX}`,
-      runtimeClip.duration,
+      `${mixerClip.name}${ADDITIVE_BAKED_MIXER_CLIP_SUFFIX}`,
+      mixerClip.duration,
       additiveTracks
     );
     if (additiveTracks.length > 0) {
       const referenceClip = new AnimationClip(
-        `${runtimeClip.name}${ADDITIVE_BAKED_RUNTIME_CLIP_SUFFIX}_reference`,
+        `${mixerClip.name}${ADDITIVE_BAKED_MIXER_CLIP_SUFFIX}_reference`,
         0,
         referenceTracks
       );
@@ -522,17 +525,17 @@ export class BakedAnimationController {
     return additiveClip;
   }
 
-  private getOrCreateBakedAdditiveRuntimeClip(runtimeClip: AnimationClip): AnimationClip | null {
-    const cached = this.bakedAdditiveRuntimeClips.get(runtimeClip.name);
+  private getOrCreateBakedAdditiveMixerClip(mixerClip: AnimationClip): AnimationClip | null {
+    const cached = this.bakedAdditiveMixerClips.get(mixerClip.name);
     if (cached) {
       return cached;
     }
 
-    const additiveClip = this.createAdditiveRuntimeClip(runtimeClip);
+    const additiveClip = this.createAdditiveMixerClip(mixerClip);
     if (!additiveClip) {
       return null;
     }
-    this.bakedAdditiveRuntimeClips.set(runtimeClip.name, additiveClip);
+    this.bakedAdditiveMixerClips.set(mixerClip.name, additiveClip);
     return additiveClip;
   }
 
@@ -911,25 +914,25 @@ export class BakedAnimationController {
     return 0;
   }
 
-  private getOrCreateBakedRuntimeAction(
+  private getOrCreateBakedMixerAction(
     sourceClipName: string,
     channel: BakedClipChannel,
     blendMode: AnimationBlendMode = 'replace'
   ): AnimationAction | null {
     const bakedClip = this.getBakedSourceClip(sourceClipName);
-    const runtimeClip = bakedClip?.runtimeClips.find((entry) => entry.channel === channel)?.clip;
-    if (!runtimeClip) {
+    const mixerClip = bakedClip?.mixerClips.find((entry) => entry.channel === channel)?.clip;
+    if (!mixerClip) {
       return null;
     }
 
     const desiredClip = blendMode === 'additive'
-      ? this.getOrCreateBakedAdditiveRuntimeClip(runtimeClip)
-      : runtimeClip;
+      ? this.getOrCreateBakedAdditiveMixerClip(mixerClip)
+      : mixerClip;
     if (!desiredClip) {
       return null;
     }
 
-    const existing = this.bakedRuntimeActions.get(runtimeClip.name);
+    const existing = this.bakedMixerActions.get(mixerClip.name);
     if (existing?.getClip() === desiredClip) {
       return existing;
     }
@@ -940,11 +943,11 @@ export class BakedAnimationController {
     }
 
     if (existing) {
-      this.releaseBakedRuntimeAction(runtimeClip.name);
+      this.releaseBakedMixerAction(mixerClip.name);
     }
 
     const action = this.animationMixer.clipAction(desiredClip);
-    this.bakedRuntimeActions.set(runtimeClip.name, action);
+    this.bakedMixerActions.set(mixerClip.name, action);
     return action;
   }
 
@@ -966,18 +969,18 @@ export class BakedAnimationController {
     }
 
     const channelActions = new Map<BakedClipChannel, AnimationAction>();
-    for (const runtimeClip of bakedClip.runtimeClips) {
+    for (const mixerClip of bakedClip.mixerClips) {
       const channelBlendMode = resolveBakedChannelBlendMode(
-        runtimeClip.channel,
+        mixerClip.channel,
         playbackState.requestedBlendMode
       ) ?? 'replace';
-      const action = this.getOrCreateBakedRuntimeAction(
+      const action = this.getOrCreateBakedMixerAction(
         clipName,
-        runtimeClip.channel,
+        mixerClip.channel,
         channelBlendMode
       );
       if (action) {
-        channelActions.set(runtimeClip.channel, action);
+        channelActions.set(mixerClip.channel, action);
       }
     }
 
@@ -1088,7 +1091,7 @@ export class BakedAnimationController {
 
   dispose(): void {
     this.stopAllAnimations();
-    this.clearAllBakedAdditiveRuntimeClips();
+    this.clearAllBakedAdditiveMixerClips();
     if (this.animationMixer) {
       this.animationMixer.stopAllAction();
       this.animationMixer = null;
@@ -1101,10 +1104,10 @@ export class BakedAnimationController {
     this.clipMixerFinishedListenerAttached = false;
     this.animationClips = [];
     this.bakedSourceClips.clear();
-    this.bakedRuntimeActions.clear();
-    this.bakedAdditiveRuntimeClips.clear();
+    this.bakedMixerActions.clear();
+    this.bakedAdditiveMixerClips.clear();
     this.bakedActionGroups.clear();
-    this.bakedRuntimeClipToSource.clear();
+    this.bakedMixerClipToSource.clear();
     this.animationActions.clear();
     this.animationFinishedCallbacks.clear();
     this.clipActions.clear();
@@ -1126,19 +1129,19 @@ export class BakedAnimationController {
     }
     if (this.animationMixer) {
       for (const bakedClip of this.bakedSourceClips.values()) {
-        for (const runtimeClip of bakedClip.runtimeClips) {
-          this.releaseBakedRuntimeAction(runtimeClip.clip.name);
-          this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
+        for (const mixerClip of bakedClip.mixerClips) {
+          this.releaseBakedMixerAction(mixerClip.clip.name);
+          this.clearBakedAdditiveMixerClip(mixerClip.clip.name);
           try {
-            this.animationMixer.uncacheAction(runtimeClip.clip);
+            this.animationMixer.uncacheAction(mixerClip.clip);
           } catch {}
           try {
-            this.animationMixer.uncacheClip(runtimeClip.clip);
+            this.animationMixer.uncacheClip(mixerClip.clip);
           } catch {}
         }
       }
     }
-    this.clearAllBakedAdditiveRuntimeClips();
+    this.clearAllBakedAdditiveMixerClips();
 
     for (const clipName of this.bakedSourceClips.keys()) {
       this.playbackState.delete(clipName);
@@ -1146,9 +1149,9 @@ export class BakedAnimationController {
     }
 
     this.bakedSourceClips.clear();
-    this.bakedRuntimeActions.clear();
+    this.bakedMixerActions.clear();
     this.bakedActionGroups.clear();
-    this.bakedRuntimeClipToSource.clear();
+    this.bakedMixerClipToSource.clear();
 
     this.ensureMixer();
     const partitionedClips = (clips as AnimationClip[]).map((clip) => (
@@ -1159,10 +1162,10 @@ export class BakedAnimationController {
     for (const bakedClip of partitionedClips) {
       this.bakedSourceClips.set(bakedClip.sourceClip.name, bakedClip);
       this.clipSources.set(bakedClip.sourceClip.name, 'baked');
-      for (const runtimeClip of bakedClip.runtimeClips) {
-        this.bakedRuntimeClipToSource.set(runtimeClip.clip.name, {
+      for (const mixerClip of bakedClip.mixerClips) {
+        this.bakedMixerClipToSource.set(mixerClip.clip.name, {
           sourceClipName: bakedClip.sourceClip.name,
-          channel: runtimeClip.channel,
+          channel: mixerClip.channel,
         });
       }
     }
@@ -1187,17 +1190,17 @@ export class BakedAnimationController {
     this.stopAnimation(clipName);
 
     if (this.animationMixer) {
-      for (const runtimeClip of bakedClip.runtimeClips) {
-        const action = this.bakedRuntimeActions.get(runtimeClip.clip.name);
-        this.releaseBakedRuntimeAction(runtimeClip.clip.name);
-        this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
+      for (const mixerClip of bakedClip.mixerClips) {
+        const action = this.bakedMixerActions.get(mixerClip.clip.name);
+        this.releaseBakedMixerAction(mixerClip.clip.name);
+        this.clearBakedAdditiveMixerClip(mixerClip.clip.name);
         try {
-          this.animationMixer.uncacheAction(runtimeClip.clip);
+          this.animationMixer.uncacheAction(mixerClip.clip);
         } catch {}
         try {
-          this.animationMixer.uncacheClip(runtimeClip.clip);
+          this.animationMixer.uncacheClip(mixerClip.clip);
         } catch {}
-        this.bakedRuntimeClipToSource.delete(runtimeClip.clip.name);
+        this.bakedMixerClipToSource.delete(mixerClip.clip.name);
         const actionId = this.getActionId(action);
         if (actionId && action) {
           this.actionIdToClip.delete(actionId);
@@ -1205,9 +1208,9 @@ export class BakedAnimationController {
         }
       }
     }
-    for (const runtimeClip of bakedClip.runtimeClips) {
-      this.clearBakedAdditiveRuntimeClip(runtimeClip.clip.name);
-      this.bakedRuntimeActions.delete(runtimeClip.clip.name);
+    for (const mixerClip of bakedClip.mixerClips) {
+      this.clearBakedAdditiveMixerClip(mixerClip.clip.name);
+      this.bakedMixerActions.delete(mixerClip.clip.name);
     }
 
     this.animationClips = this.animationClips.filter((entry) => entry.name !== clipName);
@@ -1233,7 +1236,7 @@ export class BakedAnimationController {
     playbackState.blendMode = this.getBakedAggregateBlendMode(clipName, playbackState);
     const actionGroup = this.createBakedActionGroup(clipName, playbackState);
     if (!actionGroup) {
-      console.warn(`Loom3: Animation clip "${clipName}" has no character-runtime channels to play`);
+      console.warn(`Loom3: Animation clip "${clipName}" has no character mixer channels to play`);
       return null;
     }
 
@@ -1535,7 +1538,7 @@ export class BakedAnimationController {
           const previousTime = currentAction.time;
           const wasActive = currentAction.isRunning() || currentAction.paused;
           const wasPaused = currentAction.paused;
-          const action = this.getOrCreateBakedRuntimeAction(clipName, channel, channelBlendMode);
+          const action = this.getOrCreateBakedMixerAction(clipName, channel, channelBlendMode);
           if (!action) {
             bakedGroup.channelActions.delete(channel);
             continue;
@@ -2590,10 +2593,10 @@ export class BakedAnimationController {
       }
     }
     const clip = action.getClip();
-    const bakedRuntime = this.bakedRuntimeClipToSource.get(clip.name);
-    if (bakedRuntime) {
-      const group = this.bakedActionGroups.get(bakedRuntime.sourceClipName);
-      if (group && group.pendingFinishedChannels.delete(bakedRuntime.channel) && group.pendingFinishedChannels.size === 0) {
+    const bakedMixerClip = this.bakedMixerClipToSource.get(clip.name);
+    if (bakedMixerClip) {
+      const group = this.bakedActionGroups.get(bakedMixerClip.sourceClipName);
+      if (group && group.pendingFinishedChannels.delete(bakedMixerClip.channel) && group.pendingFinishedChannels.size === 0) {
         group.resolveFinished();
       }
       return;
@@ -2642,3 +2645,6 @@ export class BakedAnimationController {
     };
   }
 }
+
+/** @deprecated Use AnimationController. */
+export { AnimationController as BakedAnimationController };

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -202,6 +202,12 @@ export class Loom3 implements LoomLarge {
       getMeshByName: (name) => this.meshByName.get(name),
       getMeshNamesForAU: (auId) => this.getMeshNamesForAU(auId),
       getMeshNamesForViseme: () => this.getMeshNamesForViseme(),
+      getCurrentAUValue: (auId) => this.getAU(auId),
+      getCurrentVisemeValue: (visemeIndex) => this.visemeValues[visemeIndex] ?? 0,
+      getCurrentMorphValue: (morphKey, meshNames) => this.getMorphValueForMeshes(morphKey, meshNames),
+      getCurrentMorphIndexValue: (morphIndex, meshNames) => this.getMorphValueByIndexForMeshes(morphIndex, meshNames),
+      getCurrentBoneQuaternion: (nodeKey) => this.bones[nodeKey]?.obj.quaternion.clone() ?? null,
+      getCurrentBonePositionValue: (nodeKey, axis) => this.bones[nodeKey]?.obj.position[axis] ?? null,
       getBones: () => this.bones,
       getConfig: () => this.config,
       getCompositeRotations: () => this.compositeRotations,
@@ -1612,6 +1618,14 @@ export class Loom3 implements LoomLarge {
     return 0;
   }
 
+  private getMorphValueForMeshes(key: string, meshNames?: string[]): number {
+    const targets = this.resolveMorphTargets(key, meshNames);
+    if (targets.length > 0) {
+      return targets[0].infl[targets[0].idx] ?? 0;
+    }
+    return this.getMorphValue(key);
+  }
+
   private getMorphValueByIndex(index: number): number {
     const idx = Number.isInteger(index) && index >= 0 ? index : null;
     if (idx === null) return 0;
@@ -1628,6 +1642,14 @@ export class Loom3 implements LoomLarge {
       if (idx < infl.length) return infl[idx] ?? 0;
     }
     return 0;
+  }
+
+  private getMorphValueByIndexForMeshes(index: number, meshNames?: string[]): number {
+    const targets = this.resolveMorphTargetsByIndex(index, meshNames);
+    if (targets.length > 0) {
+      return targets[0].infl[targets[0].idx] ?? 0;
+    }
+    return this.getMorphValueByIndex(index);
   }
 
   private applyMorphTargetDelta(target: MorphTargetDelta, options: AddMorphTargetOptions): number {

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -39,7 +39,7 @@ import type {
   AddMorphTargetOptions,
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
-import { AnimationThree, BakedAnimationController } from './AnimationThree';
+import { AnimationThree, AnimationController } from './AnimationThree';
 import { getSideScale } from './balanceUtils';
 import { HairPhysicsController, type HairPhysicsConfig, type HairPhysicsConfigUpdate, type HairPhysicsDirectionConfig, type HairMorphTargets } from './hair/HairPhysicsController';
 import { CC4_PRESET, CC4_MESHES, COMPOSITE_ROTATIONS as CC4_COMPOSITE_ROTATIONS } from '../../presets/cc4';
@@ -162,7 +162,7 @@ export class Loom3 implements LoomLarge {
     0.12, 0.18, 0.02, 0.25, 0.60, 0.40,
   ];
 
-  private bakedAnimations: BakedAnimationController;
+  private animationController: AnimationController;
   private hairPhysics: HairPhysicsController;
 
   // Internal animation loop
@@ -196,7 +196,7 @@ export class Loom3 implements LoomLarge {
     this.compositeRotations = this.config.compositeRotations || CC4_COMPOSITE_ROTATIONS;
     this.auToCompositeMap = buildAUToCompositeMap(this.compositeRotations);
 
-    this.bakedAnimations = new BakedAnimationController({
+    this.animationController = new AnimationController({
       getModel: () => this.model,
       getMeshes: () => this.meshes,
       getMeshByName: (name) => this.meshByName.get(name),
@@ -220,9 +220,9 @@ export class Loom3 implements LoomLarge {
     this.hairPhysics = new HairPhysicsController({
       getMeshByName: (name) => this.meshByName.get(name),
       getSelectedHairMeshNames: () => this.config.morphToMesh?.hair || [],
-      // Hair physics needs clip construction, but mixer ownership still lives in BakedAnimationController.
-      buildClip: (clipName, curves, options) => this.bakedAnimations.buildClip(clipName, curves, options),
-      cleanupSnippet: (name) => this.bakedAnimations.cleanupSnippet(name),
+      // Hair physics reuses the shared mixer-backed clip builder.
+      buildClip: (clipName, curves, options) => this.animationController.buildClip(clipName, curves, options),
+      cleanupSnippet: (name) => this.animationController.cleanupSnippet(name),
     });
 
     this.applyHairPhysicsProfileConfig();
@@ -436,7 +436,7 @@ export class Loom3 implements LoomLarge {
     this.animation.tick(dtSeconds);
     this.flushPendingComposites();
 
-    this.bakedAnimations.update(dtSeconds);
+    this.animationController.update(dtSeconds);
     this.hairPhysics.update(dtSeconds);
   }
 
@@ -469,7 +469,7 @@ export class Loom3 implements LoomLarge {
   dispose(): void {
     this.stop();
     this.clearTransitions();
-    this.bakedAnimations.dispose();
+    this.animationController.dispose();
     this.meshes = [];
     this.model = null;
     this.bones = {};
@@ -2239,87 +2239,87 @@ export class Loom3 implements LoomLarge {
   // ============================================================================
 
   loadAnimationClips(clips: unknown[]): void {
-    this.bakedAnimations.loadAnimationClips(clips);
+    this.animationController.loadAnimationClips(clips);
   }
 
   getAnimationClips(): AnimationClipInfo[] {
-    return this.bakedAnimations.getAnimationClips();
+    return this.animationController.getAnimationClips();
   }
 
   removeAnimationClip(clipName: string): boolean {
-    return this.bakedAnimations.removeAnimationClip(clipName);
+    return this.animationController.removeAnimationClip(clipName);
   }
 
   playAnimation(clipName: string, options: AnimationPlayOptions = {}): AnimationActionHandle | null {
-    return this.bakedAnimations.playAnimation(clipName, options);
+    return this.animationController.playAnimation(clipName, options);
   }
 
   stopAnimation(clipName: string): void {
-    this.bakedAnimations.stopAnimation(clipName);
+    this.animationController.stopAnimation(clipName);
   }
 
   stopAllAnimations(): void {
-    this.bakedAnimations.stopAllAnimations();
+    this.animationController.stopAllAnimations();
   }
 
   pauseAnimation(clipName: string): void {
-    this.bakedAnimations.pauseAnimation(clipName);
+    this.animationController.pauseAnimation(clipName);
   }
 
   resumeAnimation(clipName: string): void {
-    this.bakedAnimations.resumeAnimation(clipName);
+    this.animationController.resumeAnimation(clipName);
   }
 
   pauseAllAnimations(): void {
-    this.bakedAnimations.pauseAllAnimations();
+    this.animationController.pauseAllAnimations();
   }
 
   resumeAllAnimations(): void {
-    this.bakedAnimations.resumeAllAnimations();
+    this.animationController.resumeAllAnimations();
   }
 
   setAnimationSpeed(clipName: string, speed: number): void {
-    this.bakedAnimations.setAnimationSpeed(clipName, speed);
+    this.animationController.setAnimationSpeed(clipName, speed);
   }
 
   setAnimationIntensity(clipName: string, intensity: number): void {
-    this.bakedAnimations.setAnimationIntensity(clipName, intensity);
+    this.animationController.setAnimationIntensity(clipName, intensity);
   }
 
   setAnimationLoopMode(clipName: string, loopMode: 'repeat' | 'once' | 'pingpong'): void {
-    this.bakedAnimations.setAnimationLoopMode(clipName, loopMode);
+    this.animationController.setAnimationLoopMode(clipName, loopMode);
   }
 
   setAnimationRepeatCount(clipName: string, repeatCount?: number): void {
-    this.bakedAnimations.setAnimationRepeatCount(clipName, repeatCount);
+    this.animationController.setAnimationRepeatCount(clipName, repeatCount);
   }
 
   setAnimationReverse(clipName: string, reverse: boolean): void {
-    this.bakedAnimations.setAnimationReverse(clipName, reverse);
+    this.animationController.setAnimationReverse(clipName, reverse);
   }
 
   setAnimationBlendMode(clipName: string, blendMode: AnimationBlendMode): void {
-    this.bakedAnimations.setAnimationBlendMode(clipName, blendMode);
+    this.animationController.setAnimationBlendMode(clipName, blendMode);
   }
 
   seekAnimation(clipName: string, time: number): void {
-    this.bakedAnimations.seekAnimation(clipName, time);
+    this.animationController.seekAnimation(clipName, time);
   }
 
   setAnimationTimeScale(timeScale: number): void {
-    this.bakedAnimations.setAnimationTimeScale(timeScale);
+    this.animationController.setAnimationTimeScale(timeScale);
   }
 
   getAnimationState(clipName: string): AnimationState | null {
-    return this.bakedAnimations.getAnimationState(clipName);
+    return this.animationController.getAnimationState(clipName);
   }
 
   getPlayingAnimations(): AnimationState[] {
-    return this.bakedAnimations.getPlayingAnimations();
+    return this.animationController.getPlayingAnimations();
   }
 
   crossfadeTo(clipName: string, duration = 0.3, options: AnimationPlayOptions = {}): AnimationActionHandle | null {
-    return this.bakedAnimations.crossfadeTo(clipName, duration, options);
+    return this.animationController.crossfadeTo(clipName, duration, options);
   }
 
   snippetToClip(
@@ -2327,18 +2327,18 @@ export class Loom3 implements LoomLarge {
     curves: CurvesMap,
     options?: ClipOptions
   ): AnimationClip | null {
-    return this.bakedAnimations.snippetToClip(clipName, curves, options);
+    return this.animationController.snippetToClip(clipName, curves, options);
   }
 
   playClip(clip: AnimationClip, options?: ClipOptions): ClipHandle | null {
-    return this.bakedAnimations.playClip(clip, options);
+    return this.animationController.playClip(clip, options);
   }
 
   playSnippet(
     snippet: Snippet | { name: string; curves: CurvesMap },
     options?: ClipOptions
   ): ClipHandle | null {
-    return this.bakedAnimations.playSnippet(snippet, options);
+    return this.animationController.playSnippet(snippet, options);
   }
 
   buildClip(
@@ -2346,23 +2346,23 @@ export class Loom3 implements LoomLarge {
     curves: CurvesMap,
     options?: ClipOptions
   ): ClipHandle | null {
-    return this.bakedAnimations.buildClip(clipName, curves, options);
+    return this.animationController.buildClip(clipName, curves, options);
   }
 
   cleanupSnippet(name: string) {
-    this.bakedAnimations.cleanupSnippet(name);
+    this.animationController.cleanupSnippet(name);
   }
 
   updateClipParams(
     name: string,
     params: { weight?: number; rate?: number; loop?: boolean; loopMode?: 'once' | 'repeat' | 'pingpong'; repeatCount?: number; reverse?: boolean; actionId?: string }
   ): boolean {
-    return this.bakedAnimations.updateClipParams(name, params);
+    return this.animationController.updateClipParams(name, params);
   }
 
   /**
    * Check if curves can be played through buildClip.
-   * Returns false if curves contain bone-only AUs that can't be baked to morph tracks.
+   * Returns false if curves contain data that cannot be converted to mixer tracks.
    */
   supportsClipCurves(
     curves: Record<string, Array<{ time: number; intensity: number; inherit?: boolean }>>

--- a/src/engines/three/bakedClipPartitioning.test.ts
+++ b/src/engines/three/bakedClipPartitioning.test.ts
@@ -67,12 +67,12 @@ describe('bakedClipPartitioning', () => {
       { channel: 'body', trackCount: 1, playable: true, blendMode: 'replace' },
       { channel: 'scene', trackCount: 1, playable: false, blendMode: undefined },
     ]);
-    expect(partitioned.runtimeClips.map((entry) => entry.channel)).toEqual(['face', 'body']);
-    expect(partitioned.runtimeClips[0]?.clip.tracks.map((track) => track.name)).toEqual([
+    expect(partitioned.mixerClips.map((entry) => entry.channel)).toEqual(['face', 'body']);
+    expect(partitioned.mixerClips[0]?.clip.tracks.map((track) => track.name)).toEqual([
       'FaceMesh.morphTargetInfluences[0]',
       `${head.uuid}.quaternion`,
     ]);
-    expect(partitioned.runtimeClips[1]?.clip.tracks.map((track) => track.name)).toEqual([
+    expect(partitioned.mixerClips[1]?.clip.tracks.map((track) => track.name)).toEqual([
       `${hip.uuid}.position[x]`,
     ]);
   });

--- a/src/engines/three/bakedClipPartitioning.ts
+++ b/src/engines/three/bakedClipPartitioning.ts
@@ -11,13 +11,13 @@ import type {
 } from '../../core/types';
 import type { ResolvedBones } from './types';
 
-const RUNTIME_CLIP_PREFIX = '__loom3_baked_partition__/';
+const MIXER_CLIP_PREFIX = '__loom3_baked_partition__/';
 const FACE_SAFE_TARGET_RE = /(head|neck|jaw|eye|brow|lid|mouth|lip|face|cheek|nose|tongue|teeth)/i;
 const BODY_LIKE_TARGET_RE = /(root|armature|hips?|pelvis|spine|waist|chest|torso|shoulder|arm|forearm|hand|finger|leg|thigh|calf|knee|foot|toe|tail|wing|fin|body|abdomen|clavicle)/i;
 const SCENE_LIKE_TARGET_RE = /(camera|cam|scene|world|global|origin|pivot|cube)/i;
 const CHANNEL_ORDER: BakedClipChannel[] = ['face', 'body', 'scene'];
 
-export interface PartitionedBakedRuntimeClip {
+export interface PartitionedBakedMixerClip {
   channel: BakedClipChannel;
   clip: AnimationClip;
 }
@@ -25,7 +25,7 @@ export interface PartitionedBakedRuntimeClip {
 export interface PartitionedBakedClip {
   sourceClip: AnimationClip;
   channels: BakedClipChannelInfo[];
-  runtimeClips: PartitionedBakedRuntimeClip[];
+  mixerClips: PartitionedBakedMixerClip[];
 }
 
 type ParsedTrackTarget = {
@@ -34,8 +34,8 @@ type ParsedTrackTarget = {
   targetName: string;
 };
 
-function getRuntimeClipName(sourceClipName: string, channel: BakedClipChannel): string {
-  return `${RUNTIME_CLIP_PREFIX}${sourceClipName}/${channel}`;
+function getMixerClipName(sourceClipName: string, channel: BakedClipChannel): string {
+  return `${MIXER_CLIP_PREFIX}${sourceClipName}/${channel}`;
 }
 
 function parseTrackTarget(trackName: string, model: Object3D): ParsedTrackTarget | null {
@@ -161,7 +161,7 @@ export function partitionBakedClip(
     tracksByChannel.get(channel)?.push(track.clone());
   }
 
-  const runtimeClips: PartitionedBakedRuntimeClip[] = [];
+  const mixerClips: PartitionedBakedMixerClip[] = [];
   const channels: BakedClipChannelInfo[] = [];
 
   for (const channel of CHANNEL_ORDER) {
@@ -183,15 +183,15 @@ export function partitionBakedClip(
       continue;
     }
 
-    runtimeClips.push({
+    mixerClips.push({
       channel,
-      clip: new AnimationClip(getRuntimeClipName(clip.name, channel), clip.duration, tracks),
+      clip: new AnimationClip(getMixerClipName(clip.name, channel), clip.duration, tracks),
     });
   }
 
   return {
     sourceClip: clip,
     channels,
-    runtimeClips,
+    mixerClips,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export type {
   CompositeRotation,
   CompositeRotationState,
   RotationsState,
-  // Baked animation types
+  // Mixer animation types
   AnimationSource,
   AnimationBlendMode,
   AnimationEasing,
@@ -92,7 +92,7 @@ export type {
   AnimationClipInfo,
   AnimationState,
   AnimationActionHandle,
-  // Snippet-to-clip types
+  // Dynamic clip types
   CurvePoint,
   CurvesMap,
   ClipOptions,

--- a/src/interfaces/Animation.ts
+++ b/src/interfaces/Animation.ts
@@ -231,14 +231,14 @@ export interface Animation {
   getAnimationClips(): AnimationClipInfo[];
 
   /**
-   * Remove a baked animation clip by name.
-   * @param clipName - Name of the baked animation clip to remove
+   * Remove a loaded animation clip by name.
+   * @param clipName - Name of the animation clip to remove
    * @returns True when the clip existed and was removed
    */
   removeAnimationClip(clipName: string): boolean;
 
   /**
-   * Play a baked animation by name.
+   * Play a loaded animation clip by name.
    * @param clipName - Name of the animation clip to play
    * @param options - Playback options (speed, intensity, loop, etc.)
    * @returns Handle for controlling the animation, or null if clip not found
@@ -404,7 +404,7 @@ export interface Animation {
 
   /**
    * Check if the given curves can be played through buildClip.
-   * Returns false if curves contain bone-only AUs that can't be baked.
+   * Returns false if curves contain data that cannot be converted to mixer tracks.
    */
   supportsClipCurves(
     curves: Record<string, Array<CurvePoint>>


### PR DESCRIPTION
## Summary
- Adds support for snippet curves whose first keyframe uses `inherit: true`, treating the first point as a live-value anchor instead of an authored reset.
- Captures current morph, AU, viseme, bone rotation, and bone translation values through the Loom3 host so inherited starts work across direct morph tracks, AU-driven morphs, viseme jaw tracks, composite rotations, and translation bindings.
- Rebuilds inherited dynamic clips at playback/replay time so Firestore-loaded snippets transition from the character's current pose, not stale clip-construction values.
- Renames the mixed mixer owner from `BakedAnimationController` to `AnimationController`, updates Loom3 internals/tests/docs to stop implying procedural snippets are baked animations, and keeps deprecated aliases for deep-import compatibility.
- Renames derived baked "runtime clips" to "mixer clips" so the code reflects Three.js `AnimationMixer` ownership instead of implying a parallel Loom3 animation runtime.

## Re-evaluation Notes
Latest `origin/main` now includes the camera helper exports LoomLarge imports from published `@lovelace_lol/loom3@1.0.47`; this branch was rebased onto current `origin/main` on May 14, 2026 so linked LoomLarge installs no longer lose those exports.

`CurvePoint.inherit` was still only a type/documentation hint before this PR, and the mixer path sampled first keyframes as authored absolute values. This PR keeps the existing snippet schema and adds live target readers plus inherited-source metadata so playback resolves the first keyframe against current character state.

The controller rename is intentionally a naming/ownership correction, not a behavioral rewrite: Loom3 still uses Three.js `AnimationMixer` for playback. The old `BakedAnimationController` and `BakedAnimationHost` names remain as deprecated aliases to avoid breaking consumers that deep-imported them.

## Linked Work
- Addresses meekmachine/Loom3#136
- Required by scheduler-backed gaze in meekmachine/Latticework#28
- Required by linked UI/profile validation in meekmachine/LoomLarge#590

## Validation
- `npm run typecheck`
- `npm test -- --run src/engines/three/AnimationThree.inheritedKeyframes.test.ts src/engines/three/AnimationThree.playbackState.test.ts src/engines/three/bakedClipPartitioning.test.ts`
- `npm test -- --run`
- `npm run build`
- `git diff --check`