### PR TITLE
[codex] Add Loom3 lip-sync sequence compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,7 @@ Open in LoomLarge: [Visemes tab](https://www.characterloom.com/?drawer=open&tab=
 
 This screenshot was captured before the viseme label refresh, so some cards still show legacy names such as `Er`, `IH`, and `W_OO`. Treat the table below as the source of truth for the current exported `VISEME_KEYS` order.
 
-Visemes are mouth shapes used for lip-sync. Loom3 includes 15 visemes with automatic jaw coupling.
+Visemes are mouth shapes used for lip-sync. Loom3's CC4 preset includes 15 profile slots with automatic jaw coupling. Provider streams such as Microsoft/Azure keep their original source IDs until Loom3 resolves them through `visemeSlots[*].providerIds`, caller-supplied mappings, and the active profile bindings.
 
 ### The 15 visemes
 
@@ -1402,30 +1402,30 @@ The `VISEME_KEYS` export uses unprefixed keys in this order.
 
 | Index | Key | Phoneme Example |
 |-------|-----|-----------------|
-| 0 | EE | "b**ee**" |
+| 0 | AE | "c**a**t" |
 | 1 | Ah | "f**a**ther" |
-| 2 | Oh | "g**o**" |
-| 3 | OO | "t**oo**" |
-| 4 | I | "s**i**t" |
-| 5 | U | "fl**u**te" |
-| 6 | W | "**w**e" |
-| 7 | L | "**l**ip" |
-| 8 | F_V | "**f**un, **v**an" |
-| 9 | Th | "**th**ink" |
-| 10 | S_Z | "**s**un, **z**oo" |
-| 11 | B_M_P | "**b**at, **m**an, **p**op" |
-| 12 | K_G_H_NG | "**k**ite, **g**o, **h**at, si**ng**" |
-| 13 | AE | "c**a**t" |
-| 14 | R | "**r**ed" |
+| 2 | B_M_P | "**b**at, **m**an, **p**op" |
+| 3 | Ch_J | "**ch**in, **j**am" |
+| 4 | EE | "b**ee**" |
+| 5 | Er | "h**er**" |
+| 6 | F_V | "**f**un, **v**an" |
+| 7 | Ih | "s**i**t" |
+| 8 | K_G_H_NG | "**k**ite, **g**o, si**ng**" |
+| 9 | Oh | "g**o**" |
+| 10 | R | "**r**ed" |
+| 11 | S_Z | "**s**un, **z**oo" |
+| 12 | T_L_D_N | "**t**op, **l**ip, **d**og, **n**o" |
+| 13 | Th | "**th**ink" |
+| 14 | W_OO | "**w**e, t**oo**" |
 
 ### Setting a viseme
 
 ```typescript
-// Set viseme 3 (Ah) to full intensity
-loom.setViseme(3, 1.0);
+// Set viseme 1 (Ah) to full intensity
+loom.setViseme(1, 1.0);
 
 // With jaw scale (0-1, default 1)
-loom.setViseme(3, 1.0, 0.5);  // Half jaw opening
+loom.setViseme(1, 1.0, 0.5);  // Half jaw opening
 ```
 
 ### Transitioning visemes
@@ -1434,10 +1434,10 @@ Viseme transitions default to 80ms and use the standard `easeInOutQuad` easing w
 
 ```typescript
 // Animate to a viseme using the default 80ms duration
-const handle = loom.transitionViseme(3, 1.0);
+const handle = loom.transitionViseme(1, 1.0);
 
 // Disable jaw coupling (duration can be omitted to use the 80ms default)
-loom.transitionViseme(3, 1.0, 80, 0);
+loom.transitionViseme(1, 1.0, 80, 0);
 ```
 
 ### Automatic jaw coupling
@@ -1447,7 +1447,41 @@ Each viseme has a predefined jaw opening amount in the preset. When you set a vi
 - `jawScale = 0.5`: Half jaw opening
 - `jawScale = 0`: No jaw movement (viseme only)
 
-### Lip-sync example
+### Provider lip-sync sequence
+
+Use `lipsyncSequence()` when a speech provider already gives timed viseme events. Loom3 parses the provider-faithful source IDs, resolves the active profile's viseme slots and morph bindings, generates jaw rotation from the profile or sequence options, and plays the result as one mixer clip.
+
+```typescript
+loom.lipsyncSequence([
+  { visemeId: 1, audioOffset: 2_000_000 },
+  { visemeId: 21, audioOffset: 4_000_000 },
+], {
+  sourceProvider: 'microsoft',
+  timeUnit: 'ticks',
+  name: 'speech-line-001',
+  // Optional: source id -> profile slot id/index, or reverse slot id -> source ids.
+  sourceVisemeMap: { ah: [1, 2], 'b-m-p': [0, 21] },
+  // Optional direct morph overrides for the active profile.
+  morphTargetToViseme: { Custom_Aah: 'ah' },
+  // Optional per-slot/source jaw amounts for this sequence.
+  jawActivation: { ah: 0.75, 'b-m-p': 0 },
+});
+```
+
+Existing viseme snippet JSON can use the same entry point:
+
+```typescript
+loom.lipsyncSequence({
+  name: 'speech-snippet',
+  snippetCategory: 'visemeSnippet',
+  snippetJawScale: 1,
+  curves: {
+    '1': [{ time: 0, intensity: 0 }, { time: 0.08, intensity: 1 }],
+  },
+});
+```
+
+### Manual lip-sync example
 
 ```typescript
 async function speak(phonemes: number[]) {
@@ -1467,7 +1501,7 @@ async function speak(phonemes: number[]) {
 }
 
 // "Hello" approximation
-speak([5, 0, 10, 4]);
+speak([5, 4, 12, 9]);
 ```
 
 ---
@@ -1870,6 +1904,7 @@ Loom3 can convert AU/morph curves into AnimationMixer clips for smooth, mixer-on
 Key APIs:
 - `snippetToClip(name, curves, options)` builds an AnimationClip from curves.
 - `playClip(clip, options)` returns a ClipHandle you can pause/resume/stop.
+- `lipsyncSequence(input, options)` compiles provider viseme timing or snippet JSON into one managed mixer clip.
 - `clipHandle.subscribe(listener)` streams lifecycle events from the runtime update loop.
 - `clipHandle.stop()` now resolves cleanly (no rejected promise).
 
@@ -2147,7 +2182,7 @@ This is a compact reference for the public surface exported by `@lovelace_lol/lo
 - `collectMorphMeshes()` gathers meshes that already expose morph targets.
 - Lifecycle: `onReady()`, `update()`, `start()`, `stop()`, `dispose()`.
 - Preset state: `setProfile()`, `getProfile()`.
-- Control APIs: `setAU()`, `transitionAU()`, `setContinuum()`, `transitionContinuum()`, `setMorph()`, `transitionMorph()`, `setViseme()`, `transitionViseme()`.
+- Control APIs: `setAU()`, `transitionAU()`, `setContinuum()`, `transitionContinuum()`, `setMorph()`, `transitionMorph()`, `setViseme()`, `transitionViseme()`, `lipsyncSequence()`.
 - Runtime morph authoring: `addMorphTarget()`, `addMorphTargets()`, `ensureMorphInfluence()`, `refreshMorphTargets()`.
 - Transition state: `pause()`, `resume()`, `getPaused()`, `clearTransitions()`, `getActiveTransitionCount()`, `resetToNeutral()`.
 
@@ -2170,11 +2205,11 @@ This is a compact reference for the public surface exported by `@lovelace_lol/lo
 - Mesh inspection: `getMeshList()`, `getMorphTargets()`, `getMorphTargetIndices()`, `getBones()`.
 - Mesh debugging: `setMeshVisible()`, `highlightMesh()`, `getMeshMaterialConfig()`, `setMeshMaterialConfig()`.
 - Hair runtime: `registerHairObjects()`, `getRegisteredHairObjects()`, `setHairPhysicsEnabled()`, `setHairPhysicsConfig()`, `validateHairMorphTargets()`, `applyHairStateToObject()`.
-- Mixer helpers: `loadAnimationClips()`, `getAnimationClips()`, `playAnimation()`, `pauseAnimation()`, `resumeAnimation()`, `stopAnimation()`, `stopAllAnimations()`, `pauseAllAnimations()`, `resumeAllAnimations()`, `setAnimationSpeed()`, `setAnimationIntensity()`, `setAnimationTimeScale()`, `getAnimationState()`, `getPlayingAnimations()`, `crossfadeTo()`, `snippetToClip()`, `playClip()`, `playSnippet()`, `buildClip()`, `updateClipParams()`, `supportsClipCurves()`.
+- Mixer helpers: `loadAnimationClips()`, `getAnimationClips()`, `playAnimation()`, `pauseAnimation()`, `resumeAnimation()`, `stopAnimation()`, `stopAllAnimations()`, `pauseAllAnimations()`, `resumeAllAnimations()`, `setAnimationSpeed()`, `setAnimationIntensity()`, `setAnimationTimeScale()`, `getAnimationState()`, `getPlayingAnimations()`, `crossfadeTo()`, `snippetToClip()`, `playClip()`, `playSnippet()`, `buildClip()`, `lipsyncSequence()`, `updateClipParams()`, `supportsClipCurves()`.
 
 ### Types and lower-level exports
 
-- Configuration/types: `Profile`, `MeshInfo`, `BlendingMode`, `TransitionHandle`, `ClipEvent`, `ClipEventListener`, `ClipHandle`, `Snippet`, `AnimationState`, `AnimationClipInfo`.
+- Configuration/types: `Profile`, `MeshInfo`, `BlendingMode`, `TransitionHandle`, `ClipEvent`, `ClipEventListener`, `ClipHandle`, `Snippet`, `LipsyncSequenceInput`, `LipsyncSequenceOptions`, `MicrosoftVisemeEvent`, `AnimationState`, `AnimationClipInfo`.
 - Standalone implementations: `AnimationThree`, `HairPhysics`, `BLENDING_MODES`.
 - Region and geometry helpers: `resolveBoneName()`, `resolveBoneNames()`, `resolveFaceCenter()`, `findFaceCenter()`, `getModelForwardDirection()`, `detectFacingDirection()`.
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -384,8 +384,111 @@ export interface ClipOptions {
    * Default: true (for backwards compatibility with transitionViseme behavior)
    */
   autoVisemeJaw?: boolean;
+  /** Optional per-slot jaw amounts for this clip. Falls back to the active profile. */
+  visemeJawAmounts?: number[];
   /** Optional source override for downstream consumers */
   source?: AnimationSource;
+}
+
+export type LipsyncTimeUnit = 'auto' | 'seconds' | 'milliseconds' | 'ticks';
+export type LipsyncVisemeKey = string | number;
+
+export interface MicrosoftVisemeEvent {
+  visemeId?: LipsyncVisemeKey;
+  viseme_id?: LipsyncVisemeKey;
+  VisemeId?: LipsyncVisemeKey;
+  id?: LipsyncVisemeKey;
+  phoneme?: string;
+  audioOffset?: number;
+  audio_offset?: number;
+  AudioOffset?: number;
+  time?: number;
+  offset?: number;
+  offsetMs?: number;
+  offset_ms?: number;
+  timeMs?: number;
+  startMs?: number;
+  duration?: number;
+  durationMs?: number;
+  duration_ms?: number;
+  animation?: unknown;
+  Animation?: unknown;
+  [key: string]: unknown;
+}
+
+export interface LipsyncSnippetInput {
+  name?: string;
+  curves: CurvesMap;
+  snippetCategory?: string;
+  snippetJawScale?: number;
+  snippetIntensityScale?: number;
+  snippetPlaybackRate?: number;
+  loop?: boolean;
+  mixerLoopMode?: ClipOptions['loopMode'];
+  mixerRepeatCount?: number;
+  mixerReverse?: boolean;
+  autoVisemeJaw?: boolean;
+  [key: string]: unknown;
+}
+
+export interface LipsyncEventListInput {
+  name?: string;
+  provider?: string;
+  sourceProvider?: string;
+  events?: MicrosoftVisemeEvent[];
+  visemes?: MicrosoftVisemeEvent[] | LipsyncVisemeKey[];
+  visemeTiming?: MicrosoftVisemeEvent[] | number[];
+  visemeTimings?: MicrosoftVisemeEvent[] | number[];
+  visemesTiming?: MicrosoftVisemeEvent[] | number[];
+  visemesTimings?: MicrosoftVisemeEvent[] | number[];
+  viseme_timing?: MicrosoftVisemeEvent[] | number[];
+  visemes_timing?: MicrosoftVisemeEvent[] | number[];
+  vsemesTiming?: MicrosoftVisemeEvent[] | number[];
+  vtimes?: number[];
+  vdurations?: number[];
+  duration?: number;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+export type LipsyncSequenceInput =
+  | MicrosoftVisemeEvent[]
+  | LipsyncEventListInput
+  | LipsyncSnippetInput;
+
+export interface LipsyncSequenceOptions extends Omit<
+  ClipOptions,
+  'snippetCategory' | 'autoVisemeJaw' | 'jawScale' | 'visemeJawAmounts'
+> {
+  name?: string;
+  sourceProvider?: string;
+  timeUnit?: LipsyncTimeUnit;
+  sourceVisemeMap?: Record<string, LipsyncVisemeKey | LipsyncVisemeKey[]>;
+  morphTargetToViseme?: Record<string, LipsyncVisemeKey>;
+  jawActivation?: Record<string, number>;
+  defaultJawScale?: number;
+  defaultVisemeDurationMs?: number;
+  rampMs?: number;
+  neutralPadMs?: number;
+}
+
+export interface NormalizedLipsyncEvent {
+  sourceId: LipsyncVisemeKey;
+  slotId: string;
+  slotIndex: number;
+  offsetMs: number;
+  durationMs: number;
+  phoneme?: string;
+  animation?: unknown;
+  raw: MicrosoftVisemeEvent;
+}
+
+export interface CompiledLipsyncSequence {
+  name: string;
+  sourceProvider: string;
+  curves: CurvesMap;
+  clipOptions: ClipOptions;
+  events: NormalizedLipsyncEvent[];
 }
 
 /**

--- a/src/engines/three/AnimationThree.ts
+++ b/src/engines/three/AnimationThree.ts
@@ -1812,7 +1812,7 @@ export class BakedAnimationController {
     // This replicates transitionViseme behavior for clip-based playback
     const autoVisemeJaw = options?.autoVisemeJaw !== false; // Default true
     const jawScale = options?.jawScale ?? 1.0;
-    const visemeJawAmounts = getVisemeJawAmounts(config);
+    const visemeJawAmounts = options?.visemeJawAmounts ?? getVisemeJawAmounts(config);
 
     if (
       autoVisemeJaw &&

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -37,6 +37,8 @@ import type {
   AnimationBlendMode,
   MorphTargetDelta,
   AddMorphTargetOptions,
+  LipsyncSequenceInput,
+  LipsyncSequenceOptions,
 } from '../../core/types';
 import { getCompositeAxisBinding, getCompositeAxisValue } from '../../core/compositeAxis';
 import { AnimationThree, BakedAnimationController } from './AnimationThree';
@@ -53,6 +55,7 @@ import {
   getVisemeJawAmounts,
   getVisemeSlotIndex,
 } from '../../mappings/visemeSystem';
+import { compileLipsyncSequence } from '../../lipsync/lipsyncSequence';
 import type { NodeBase, ResolvedBones } from './types';
 
 const deg2rad = (d: number) => (d * Math.PI) / 180;
@@ -2325,6 +2328,17 @@ export class Loom3 implements LoomLarge {
     options?: ClipOptions
   ): ClipHandle | null {
     return this.bakedAnimations.buildClip(clipName, curves, options);
+  }
+
+  lipsyncSequence(
+    input: LipsyncSequenceInput,
+    options?: LipsyncSequenceOptions
+  ): ClipHandle | null {
+    const sequence = compileLipsyncSequence(this.config, input, options);
+    if (Object.keys(sequence.curves).length === 0) {
+      return null;
+    }
+    return this.buildClip(sequence.name, sequence.curves, sequence.clipOptions);
   }
 
   cleanupSnippet(name: string) {

--- a/src/engines/three/Loom3.visemeRuntime.test.ts
+++ b/src/engines/three/Loom3.visemeRuntime.test.ts
@@ -140,4 +140,33 @@ describe('Loom3 live viseme runtime', () => {
     engine.setVisemeById('bmp', 0);
     expect(mesh.morphTargetInfluences?.[0]).toBeCloseTo(0.3);
   });
+
+  it('plays raw provider viseme timing through a Loom3-owned mixer sequence', () => {
+    const mesh = makeMorphMesh('VisemeMesh', { Viseme_AA: 0, Viseme_BMP: 1 });
+    const engine = makeEngine(makeProfile({
+      visemeSlots: [
+        { id: 'aa', label: 'AA', order: 0, providerIds: { azure: [1] }, defaultJawAmount: 0.8 },
+        { id: 'bmp', label: 'B/M/P', order: 1, providerIds: { azure: [21] }, defaultJawAmount: 0 },
+      ],
+    }), mesh);
+
+    const handle = engine.lipsyncSequence([
+      { visemeId: 1, time: 0, duration: 0.12 },
+      { visemeId: 21, time: 0.12, duration: 0.08 },
+    ], {
+      sourceProvider: 'microsoft',
+      rampMs: 10,
+      neutralPadMs: 0,
+      name: 'raw-provider-visemes',
+    });
+
+    expect(handle).toBeTruthy();
+
+    engine.update(0.02);
+    expect(mesh.morphTargetInfluences?.[0]).toBeGreaterThan(0.5);
+    expect(jawRoll(engine)).toBeGreaterThan(10);
+
+    engine.update(0.12);
+    expect(mesh.morphTargetInfluences?.[1]).toBeGreaterThan(0.5);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,11 +99,22 @@ export type {
   ClipEvent,
   ClipEventListener,
   ClipHandle,
+  LipsyncTimeUnit,
+  LipsyncVisemeKey,
+  MicrosoftVisemeEvent,
+  LipsyncSnippetInput,
+  LipsyncEventListInput,
+  LipsyncSequenceInput,
+  LipsyncSequenceOptions,
+  NormalizedLipsyncEvent,
+  CompiledLipsyncSequence,
   Snippet,
   MorphTargetAttributeData,
   MorphTargetDelta,
   AddMorphTargetOptions,
 } from './core/types';
+
+export { compileLipsyncSequence } from './lipsync';
 
 // ============================================================================
 // MAPPINGS

--- a/src/interfaces/Animation.ts
+++ b/src/interfaces/Animation.ts
@@ -17,6 +17,8 @@ import type {
   AnimationBlendMode,
   MorphTargetDelta,
   AddMorphTargetOptions,
+  LipsyncSequenceInput,
+  LipsyncSequenceOptions,
 } from '../core/types';
 
 /** Loop mode for mixer clips */
@@ -375,6 +377,16 @@ export interface Animation {
     clipName: string,
     curves: Record<string, Array<CurvePoint>>,
     options?: ClipOptions
+  ): ClipHandle | null;
+
+  /**
+   * Compile provider viseme timing or a viseme snippet into one mixer clip and play it.
+   * This is the preferred entry point for lip-sync systems that already have
+   * Microsoft/Azure viseme timing or profile-faithful viseme curves.
+   */
+  lipsyncSequence?(
+    input: LipsyncSequenceInput,
+    options?: LipsyncSequenceOptions
   ): ClipHandle | null;
 
   /**

--- a/src/lipsync/index.ts
+++ b/src/lipsync/index.ts
@@ -1,0 +1,1 @@
+export { compileLipsyncSequence } from './lipsyncSequence';

--- a/src/lipsync/lipsyncSequence.test.ts
+++ b/src/lipsync/lipsyncSequence.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { Profile } from '../mappings/types';
+import { CC4_PRESET } from '../presets/cc4';
+import { compileLipsyncSequence } from './lipsyncSequence';
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    auToMorphs: {},
+    auToBones: {},
+    boneNodes: {},
+    morphToMesh: { face: ['FaceMesh'], viseme: ['VisemeMesh'] },
+    visemeKeys: ['Mouth_Aah', 'Mouth_Closed'],
+    visemeSlots: [
+      { id: 'aa', label: 'AA', order: 0, providerIds: { azure: [1] }, defaultJawAmount: 0.7 },
+      { id: 'bmp', label: 'B/M/P', order: 1, providerIds: { azure: [21] }, defaultJawAmount: 0 },
+    ],
+    visemeMeshCategory: 'viseme',
+    visemeJawAmounts: [0.7, 0],
+    ...overrides,
+  };
+}
+
+describe('compileLipsyncSequence', () => {
+  it('compiles raw Microsoft/Azure viseme timing without pre-collapsing source ids', () => {
+    const compiled = compileLipsyncSequence(
+      CC4_PRESET,
+      [
+        { visemeId: 21, audioOffset: 2_000_000, animation: { frameIndex: 1 } },
+        { viseme_id: 1, audio_offset: 4_000_000 },
+      ],
+      { sourceProvider: 'microsoft', timeUnit: 'ticks', name: 'ms-visemes' }
+    );
+
+    expect(compiled.name).toBe('ms-visemes');
+    expect(compiled.events[0]).toMatchObject({
+      sourceId: 21,
+      slotId: 'b-m-p',
+      slotIndex: 2,
+      offsetMs: 200,
+      durationMs: 200,
+      animation: { frameIndex: 1 },
+    });
+    expect(compiled.events[1]).toMatchObject({
+      sourceId: 1,
+      slotId: 'ah',
+      slotIndex: 1,
+      offsetMs: 400,
+    });
+    expect(compiled.curves['2']).toBeDefined();
+    expect(compiled.curves['1']).toBeDefined();
+    expect(compiled.clipOptions).toMatchObject({
+      snippetCategory: 'visemeSnippet',
+      autoVisemeJaw: true,
+    });
+  });
+
+  it('supports reverse source maps keyed by profile slot id', () => {
+    const compiled = compileLipsyncSequence(
+      makeProfile(),
+      [{ id: 9, time: 0 }],
+      {
+        sourceProvider: 'custom',
+        sourceVisemeMap: { aa: [9] },
+      }
+    );
+
+    expect(compiled.events[0]).toMatchObject({
+      sourceId: 9,
+      slotId: 'aa',
+      slotIndex: 0,
+    });
+    expect(compiled.curves['0']).toBeDefined();
+  });
+
+  it('adds direct morph override curves and per-viseme jaw overrides', () => {
+    const compiled = compileLipsyncSequence(
+      makeProfile(),
+      [{ visemeId: 1, time: 0, duration: 0.12 }],
+      {
+        sourceProvider: 'azure',
+        morphTargetToViseme: { Custom_Aah: 'aa' },
+        jawActivation: { aa: 0.25 },
+      }
+    );
+
+    expect(compiled.curves.Custom_Aah).toEqual(compiled.curves['0']);
+    expect(compiled.clipOptions.meshNames).toEqual(['VisemeMesh']);
+    expect(compiled.clipOptions.visemeJawAmounts?.[0]).toBe(0.25);
+    expect(compiled.clipOptions.visemeJawAmounts?.[1]).toBe(0);
+  });
+
+  it('accepts parallel viseme and timing arrays for legacy snippet callers', () => {
+    const compiled = compileLipsyncSequence(
+      makeProfile(),
+      {
+        visemes: [1, 21],
+        vtimes: [0, 120],
+        vdurations: [80, 60],
+      },
+      { sourceProvider: 'azure' }
+    );
+
+    expect(compiled.events.map((event) => event.slotId)).toEqual(['aa', 'bmp']);
+    expect(compiled.events.map((event) => event.durationMs)).toEqual([80, 60]);
+  });
+
+  it('passes existing viseme snippet JSON through as mixer clip curves', () => {
+    const compiled = compileLipsyncSequence(
+      makeProfile(),
+      {
+        name: 'snippet',
+        snippetCategory: 'visemeSnippet',
+        snippetJawScale: 0.4,
+        snippetIntensityScale: 0.8,
+        snippetPlaybackRate: 1.2,
+        curves: {
+          0: [
+            { time: 0, intensity: 0 },
+            { time: 0.1, intensity: 1 },
+          ],
+        },
+      }
+    );
+
+    expect(compiled.events).toEqual([]);
+    expect(compiled.curves['0']).toEqual([
+      { time: 0, intensity: 0, inherit: undefined },
+      { time: 0.1, intensity: 1, inherit: undefined },
+    ]);
+    expect(compiled.clipOptions).toMatchObject({
+      jawScale: 0.4,
+      intensityScale: 0.8,
+      playbackRate: 1.2,
+      snippetCategory: 'visemeSnippet',
+    });
+  });
+});

--- a/src/lipsync/lipsyncSequence.ts
+++ b/src/lipsync/lipsyncSequence.ts
@@ -1,0 +1,531 @@
+import type {
+  ClipOptions,
+  CompiledLipsyncSequence,
+  CurvePoint,
+  CurvesMap,
+  LipsyncEventListInput,
+  LipsyncSequenceInput,
+  LipsyncSequenceOptions,
+  LipsyncSnippetInput,
+  LipsyncTimeUnit,
+  LipsyncVisemeKey,
+  MicrosoftVisemeEvent,
+  NormalizedLipsyncEvent,
+} from '../core/types';
+import type { Profile } from '../mappings/types';
+import {
+  getMeshNamesForVisemeProfile,
+  getProfileVisemeSlots,
+  getVisemeJawAmounts,
+  getVisemeSlotIndex,
+  mapProviderVisemeToSlot,
+} from '../mappings/visemeSystem';
+
+const DEFAULT_PROVIDER = 'azure';
+const DEFAULT_RAMP_MS = 8;
+const DEFAULT_VISEME_DURATION_MS = 100;
+const DEFAULT_NEUTRAL_PAD_MS = 40;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isCurvePoint(value: unknown): value is CurvePoint {
+  return isRecord(value)
+    && typeof value.time === 'number'
+    && typeof value.intensity === 'number';
+}
+
+function isSnippetInput(input: LipsyncSequenceInput): input is LipsyncSnippetInput {
+  return isRecord(input) && isRecord(input.curves);
+}
+
+function asEvent(value: unknown): MicrosoftVisemeEvent | null {
+  return isRecord(value) ? value as MicrosoftVisemeEvent : null;
+}
+
+function eventSourceId(event: MicrosoftVisemeEvent): LipsyncVisemeKey | undefined {
+  return event.visemeId
+    ?? event.viseme_id
+    ?? event.VisemeId
+    ?? event.id;
+}
+
+function providerAliases(provider: string): string[] {
+  const lower = provider.toLowerCase();
+  if (lower === 'microsoft') return ['microsoft', 'azure', 'sapi'];
+  if (lower === 'azure') return ['azure', 'sapi', 'microsoft'];
+  if (lower === 'sapi') return ['sapi', 'azure', 'microsoft'];
+  return [lower];
+}
+
+function valuesEqual(a: LipsyncVisemeKey, b: LipsyncVisemeKey): boolean {
+  return String(a).toLowerCase() === String(b).toLowerCase();
+}
+
+function lookupSourceMap(
+  sourceVisemeMap: LipsyncSequenceOptions['sourceVisemeMap'] | undefined,
+  sourceId: LipsyncVisemeKey
+): LipsyncVisemeKey | undefined {
+  if (!sourceVisemeMap) return undefined;
+
+  const direct = sourceVisemeMap[String(sourceId)];
+  if (Array.isArray(direct)) return direct[0];
+  if (direct !== undefined) return direct;
+
+  for (const [target, mapped] of Object.entries(sourceVisemeMap)) {
+    if (Array.isArray(mapped)) {
+      if (mapped.some((candidate) => valuesEqual(candidate, sourceId))) return target;
+    } else if (valuesEqual(mapped, sourceId)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveProfileVisemeIndex(profile: Profile, target: LipsyncVisemeKey): number {
+  const slots = getProfileVisemeSlots(profile);
+
+  if (typeof target === 'number' && Number.isInteger(target) && target >= 0 && target < slots.length) {
+    return target;
+  }
+
+  const targetString = String(target);
+  const numeric = Number(targetString);
+  if (Number.isInteger(numeric) && numeric >= 0 && numeric < slots.length) {
+    return numeric;
+  }
+
+  const direct = getVisemeSlotIndex(profile, targetString);
+  if (direct >= 0) return direct;
+
+  const lower = targetString.toLowerCase();
+  return slots.findIndex((slot) =>
+    slot.id.toLowerCase() === lower
+    || slot.label.toLowerCase() === lower
+  );
+}
+
+function resolveSourceVisemeIndex(
+  profile: Profile,
+  sourceId: LipsyncVisemeKey,
+  provider: string,
+  sourceVisemeMap?: LipsyncSequenceOptions['sourceVisemeMap'],
+  phoneme?: string
+): number {
+  const mapped = lookupSourceMap(sourceVisemeMap, sourceId);
+  if (mapped !== undefined) {
+    const mappedIndex = resolveProfileVisemeIndex(profile, mapped);
+    if (mappedIndex >= 0) return mappedIndex;
+  }
+
+  let fallbackRestIndex = -1;
+  for (const alias of providerAliases(provider)) {
+    const match = mapProviderVisemeToSlot(profile, { provider: alias, id: sourceId, phoneme });
+    if (!match) continue;
+    if (match.reason !== 'rest') return match.index;
+    if (fallbackRestIndex < 0) fallbackRestIndex = match.index;
+  }
+
+  const direct = resolveProfileVisemeIndex(profile, sourceId);
+  return direct >= 0 ? direct : fallbackRestIndex;
+}
+
+function resolveAnyVisemeIndex(
+  profile: Profile,
+  viseme: LipsyncVisemeKey,
+  provider: string,
+  sourceVisemeMap?: LipsyncSequenceOptions['sourceVisemeMap']
+): number {
+  const direct = resolveProfileVisemeIndex(profile, viseme);
+  if (direct >= 0) return direct;
+  return resolveSourceVisemeIndex(profile, viseme, provider, sourceVisemeMap);
+}
+
+function convertTimeToMs(value: number, unit: LipsyncTimeUnit, key: string): number {
+  if (!Number.isFinite(value)) return 0;
+  if (unit === 'milliseconds') return value;
+  if (unit === 'seconds') return value * 1000;
+  if (unit === 'ticks') return value / 10_000;
+  if (/ms/i.test(key)) return value;
+  if (/audio/i.test(key) && Math.abs(value) > 10_000) return value / 10_000;
+  return value * 1000;
+}
+
+function readTimeMs(
+  event: MicrosoftVisemeEvent,
+  unit: LipsyncTimeUnit,
+  candidates: Array<[string, unknown]>
+): number | undefined {
+  for (const [key, raw] of candidates) {
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return Math.max(0, convertTimeToMs(raw, unit, key));
+    }
+  }
+  return undefined;
+}
+
+function readOffsetMs(event: MicrosoftVisemeEvent, unit: LipsyncTimeUnit): number {
+  return readTimeMs(event, unit, [
+    ['offsetMs', event.offsetMs],
+    ['offset_ms', event.offset_ms],
+    ['timeMs', event.timeMs],
+    ['startMs', event.startMs],
+    ['audioOffset', event.audioOffset],
+    ['audio_offset', event.audio_offset],
+    ['AudioOffset', event.AudioOffset],
+    ['time', event.time],
+    ['offset', event.offset],
+  ]) ?? 0;
+}
+
+function readDurationMs(event: MicrosoftVisemeEvent, unit: LipsyncTimeUnit): number | undefined {
+  return readTimeMs(event, unit, [
+    ['durationMs', event.durationMs],
+    ['duration_ms', event.duration_ms],
+    ['duration', event.duration],
+  ]);
+}
+
+function normalizeCurve(input: unknown): CurvePoint[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter(isCurvePoint)
+    .map((point) => ({
+      time: Math.max(0, point.time),
+      intensity: Number.isFinite(point.intensity) ? point.intensity : 0,
+      inherit: point.inherit,
+    }))
+    .sort((a, b) => a.time - b.time);
+}
+
+function normalizeCurves(curves: CurvesMap): CurvesMap {
+  const normalized: CurvesMap = {};
+  for (const [key, value] of Object.entries(curves || {})) {
+    const curve = normalizeCurve(value);
+    if (curve.length > 0) normalized[key] = curve;
+  }
+  return normalized;
+}
+
+function buildVisemeCurve(offsetMs: number, durationMs: number, rampMs: number): CurvePoint[] {
+  const startSec = Math.max(0, offsetMs) / 1000;
+  const durationSec = Math.max(0, durationMs) / 1000;
+  const endSec = startSec + durationSec;
+  const rampSec = Math.min(Math.max(0, rampMs) / 1000, durationSec / 2);
+  const peakStart = startSec + rampSec;
+  const peakEnd = Math.max(peakStart, endSec - rampSec);
+
+  return [
+    { time: startSec, intensity: 0 },
+    { time: peakStart, intensity: 1 },
+    { time: peakEnd, intensity: 1 },
+    { time: endSec, intensity: 0 },
+  ];
+}
+
+function appendCurve(curves: CurvesMap, key: string, curve: CurvePoint[]): void {
+  if (!curve.length) return;
+  curves[key] = [...(curves[key] || []), ...curve]
+    .sort((a, b) => a.time - b.time)
+    .filter((point, index, arr) => {
+      if (index === 0) return true;
+      const prev = arr[index - 1];
+      return Math.abs(prev.time - point.time) > 1e-6
+        || Math.abs(prev.intensity - point.intensity) > 1e-6
+        || Boolean(point.inherit) !== Boolean(prev.inherit);
+    });
+}
+
+function addNeutralPad(curves: CurvesMap, neutralPadMs: number): void {
+  if (neutralPadMs <= 0) return;
+
+  let maxTime = 0;
+  for (const curve of Object.values(curves)) {
+    const last = curve[curve.length - 1];
+    if (last) maxTime = Math.max(maxTime, last.time);
+  }
+
+  const neutralTime = maxTime + neutralPadMs / 1000;
+  for (const curve of Object.values(curves)) {
+    const last = curve[curve.length - 1];
+    if (!last || Math.abs(last.time - neutralTime) < 1e-6) continue;
+    curve.push({ time: neutralTime, intensity: 0 });
+  }
+}
+
+function clipOptionsFromSequenceOptions(options: LipsyncSequenceOptions = {}): ClipOptions {
+  const {
+    name: _name,
+    sourceProvider: _sourceProvider,
+    timeUnit: _timeUnit,
+    sourceVisemeMap: _sourceVisemeMap,
+    morphTargetToViseme: _morphTargetToViseme,
+    jawActivation: _jawActivation,
+    defaultJawScale: _defaultJawScale,
+    defaultVisemeDurationMs: _defaultVisemeDurationMs,
+    rampMs: _rampMs,
+    neutralPadMs: _neutralPadMs,
+    ...clipOptions
+  } = options;
+  return clipOptions;
+}
+
+function getArrayField(input: Record<string, unknown>, keys: string[]): unknown[] | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (Array.isArray(value)) return value;
+  }
+  return undefined;
+}
+
+function eventsFromParallelArrays(input: Record<string, unknown>): MicrosoftVisemeEvent[] | null {
+  const visemes = input.visemes;
+  if (!Array.isArray(visemes) || visemes.every(isRecord)) return null;
+
+  const timings = getArrayField(input, [
+    'vtimes',
+    'visemeTiming',
+    'visemeTimings',
+    'visemesTiming',
+    'visemesTimings',
+    'viseme_timing',
+    'visemes_timing',
+    'vsemestiming',
+    'vsemesTiming',
+  ]);
+  const durations = getArrayField(input, ['vdurations', 'durationMs', 'durations']);
+
+  return visemes.map((viseme, index) => ({
+    visemeId: viseme as LipsyncVisemeKey,
+    offsetMs: typeof timings?.[index] === 'number' ? timings[index] as number : index * DEFAULT_VISEME_DURATION_MS,
+    durationMs: typeof durations?.[index] === 'number' ? durations[index] as number : undefined,
+  }));
+}
+
+function extractEventInput(input: LipsyncSequenceInput): {
+  name?: string;
+  provider?: string;
+  durationMs?: number;
+  events: MicrosoftVisemeEvent[];
+} {
+  if (Array.isArray(input)) {
+    return { events: input.map(asEvent).filter((event): event is MicrosoftVisemeEvent => Boolean(event)) };
+  }
+
+  if (!isRecord(input)) return { events: [] };
+
+  const parallel = eventsFromParallelArrays(input);
+  if (parallel) {
+    return {
+      name: typeof input.name === 'string' ? input.name : undefined,
+      provider: typeof input.provider === 'string'
+        ? input.provider
+        : typeof input.sourceProvider === 'string'
+          ? input.sourceProvider
+          : undefined,
+      durationMs: typeof input.durationMs === 'number'
+        ? input.durationMs
+        : typeof input.duration === 'number'
+          ? input.duration * 1000
+          : undefined,
+      events: parallel,
+    };
+  }
+
+  const rawEvents = getArrayField(input, [
+    'events',
+    'visemes',
+    'visemeTiming',
+    'visemeTimings',
+    'visemesTiming',
+    'visemesTimings',
+    'viseme_timing',
+    'visemes_timing',
+    'vsemestiming',
+    'vsemesTiming',
+  ]) || [];
+
+  return {
+    name: typeof input.name === 'string' ? input.name : undefined,
+    provider: typeof input.provider === 'string'
+      ? input.provider
+      : typeof input.sourceProvider === 'string'
+        ? input.sourceProvider
+        : undefined,
+    durationMs: typeof input.durationMs === 'number'
+      ? input.durationMs
+      : typeof input.duration === 'number'
+        ? input.duration * 1000
+        : undefined,
+    events: rawEvents.map(asEvent).filter((event): event is MicrosoftVisemeEvent => Boolean(event)),
+  };
+}
+
+function buildJawAmounts(
+  profile: Profile,
+  provider: string,
+  options: LipsyncSequenceOptions
+): number[] | undefined {
+  const slots = getProfileVisemeSlots(profile);
+  if (slots.length === 0) return undefined;
+
+  const jawAmounts = getVisemeJawAmounts(profile) || Array.from({ length: slots.length }, () => 0);
+
+  for (const [viseme, amount] of Object.entries(options.jawActivation || {})) {
+    if (!Number.isFinite(amount)) continue;
+    const index = resolveAnyVisemeIndex(profile, viseme, provider, options.sourceVisemeMap);
+    if (index >= 0 && index < jawAmounts.length) {
+      jawAmounts[index] = Math.max(0, amount);
+    }
+  }
+
+  return jawAmounts;
+}
+
+function addMorphOverrideCurves(
+  profile: Profile,
+  provider: string,
+  curves: CurvesMap,
+  options: LipsyncSequenceOptions
+): string[] {
+  const morphOverrides = options.morphTargetToViseme || {};
+  const directMorphs: string[] = [];
+
+  for (const [morphName, viseme] of Object.entries(morphOverrides)) {
+    const index = resolveAnyVisemeIndex(profile, viseme, provider, options.sourceVisemeMap);
+    if (index < 0) continue;
+    const sourceCurve = curves[String(index)];
+    if (!sourceCurve || sourceCurve.length === 0) continue;
+    appendCurve(curves, morphName, sourceCurve.map((point) => ({ ...point })));
+    directMorphs.push(morphName);
+  }
+
+  return directMorphs;
+}
+
+function compileSnippetInput(
+  _profile: Profile,
+  input: LipsyncSnippetInput,
+  options: LipsyncSequenceOptions = {}
+): CompiledLipsyncSequence {
+  const name = options.name || input.name || `lipsync_${Date.now()}`;
+  const clipOptions = clipOptionsFromSequenceOptions(options);
+
+  return {
+    name,
+    sourceProvider: options.sourceProvider || DEFAULT_PROVIDER,
+    curves: normalizeCurves(input.curves),
+    events: [],
+    clipOptions: {
+      ...clipOptions,
+      loop: clipOptions.loop ?? input.loop,
+      loopMode: clipOptions.loopMode ?? input.mixerLoopMode,
+      repeatCount: clipOptions.repeatCount ?? input.mixerRepeatCount,
+      reverse: clipOptions.reverse ?? input.mixerReverse,
+      playbackRate: clipOptions.playbackRate ?? input.snippetPlaybackRate,
+      intensityScale: clipOptions.intensityScale ?? input.snippetIntensityScale,
+      jawScale: input.snippetJawScale ?? options.defaultJawScale ?? 1,
+      snippetCategory: 'visemeSnippet',
+      autoVisemeJaw: input.autoVisemeJaw !== false,
+      source: clipOptions.source ?? 'clip',
+    },
+  };
+}
+
+export function compileLipsyncSequence(
+  profile: Profile,
+  input: LipsyncSequenceInput,
+  options: LipsyncSequenceOptions = {}
+): CompiledLipsyncSequence {
+  if (isSnippetInput(input)) {
+    return compileSnippetInput(profile, input, options);
+  }
+
+  const eventInput = extractEventInput(input);
+  const provider = options.sourceProvider || eventInput.provider || DEFAULT_PROVIDER;
+  const sourceProvider = provider.toLowerCase();
+  const timeUnit = options.timeUnit || 'auto';
+  const rampMs = options.rampMs ?? DEFAULT_RAMP_MS;
+  const defaultDurationMs = options.defaultVisemeDurationMs ?? DEFAULT_VISEME_DURATION_MS;
+  const neutralPadMs = options.neutralPadMs ?? DEFAULT_NEUTRAL_PAD_MS;
+  const slots = getProfileVisemeSlots(profile);
+  const normalized: NormalizedLipsyncEvent[] = [];
+
+  const rawEvents = eventInput.events
+    .map((event) => ({
+      event,
+      sourceId: eventSourceId(event),
+      offsetMs: readOffsetMs(event, timeUnit),
+    }))
+    .filter((entry): entry is { event: MicrosoftVisemeEvent; sourceId: LipsyncVisemeKey; offsetMs: number } =>
+      entry.sourceId !== undefined
+    )
+    .sort((a, b) => a.offsetMs - b.offsetMs);
+
+  for (let index = 0; index < rawEvents.length; index += 1) {
+    const current = rawEvents[index];
+    const next = rawEvents[index + 1];
+    const slotIndex = resolveSourceVisemeIndex(
+      profile,
+      current.sourceId,
+      sourceProvider,
+      options.sourceVisemeMap,
+      typeof current.event.phoneme === 'string' ? current.event.phoneme : undefined
+    );
+
+    if (slotIndex < 0 || slotIndex >= slots.length) continue;
+
+    const explicitDuration = readDurationMs(current.event, timeUnit);
+    const inferredDuration = next
+      ? Math.max(0, next.offsetMs - current.offsetMs)
+      : eventInput.durationMs !== undefined
+        ? Math.max(0, eventInput.durationMs - current.offsetMs)
+        : defaultDurationMs;
+
+    normalized.push({
+      sourceId: current.sourceId,
+      slotId: slots[slotIndex].id,
+      slotIndex,
+      offsetMs: current.offsetMs,
+      durationMs: Math.max(0, explicitDuration ?? inferredDuration),
+      phoneme: typeof current.event.phoneme === 'string' ? current.event.phoneme : undefined,
+      animation: current.event.animation ?? current.event.Animation,
+      raw: current.event,
+    });
+  }
+
+  const curves: CurvesMap = {};
+  for (const event of normalized) {
+    appendCurve(
+      curves,
+      String(event.slotIndex),
+      buildVisemeCurve(event.offsetMs, event.durationMs || defaultDurationMs, rampMs)
+    );
+  }
+
+  const directMorphs = addMorphOverrideCurves(profile, sourceProvider, curves, options);
+  addNeutralPad(curves, neutralPadMs);
+
+  const clipOptions = clipOptionsFromSequenceOptions(options);
+  const visemeMeshNames = directMorphs.length > 0 && !clipOptions.meshNames
+    ? getMeshNamesForVisemeProfile(profile)
+    : undefined;
+
+  return {
+    name: options.name || eventInput.name || `lipsync_${Date.now()}`,
+    sourceProvider,
+    curves,
+    events: normalized,
+    clipOptions: {
+      ...clipOptions,
+      meshNames: clipOptions.meshNames ?? (visemeMeshNames && visemeMeshNames.length > 0 ? visemeMeshNames : undefined),
+      jawScale: options.defaultJawScale ?? 1,
+      snippetCategory: 'visemeSnippet',
+      autoVisemeJaw: true,
+      visemeJawAmounts: buildJawAmounts(profile, sourceProvider, options),
+      source: clipOptions.source ?? 'clip',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add a Loom3-owned `lipsyncSequence(input, options)` API that compiles provider viseme timing or existing viseme snippet JSON into one managed mixer clip.
- Add `compileLipsyncSequence(...)` plus public types for Microsoft/Azure event shapes, sequence options, normalized events, and compiled sequence data.
- Resolve provider source IDs through `visemeSlots[*].providerIds`, optional source mappings, profile slot ids/labels, morph-target overrides, and per-sequence jaw activation.
- Let clip playback use per-sequence `visemeJawAmounts` so jaw rotation stays inside Loom3's existing auto-viseme-jaw mixer path.
- Update README docs to separate provider source IDs from profile/rig viseme slots and document the new API.

## Research notes

Microsoft's current Azure Speech viseme docs describe 22 viseme IDs and state that `Audio offset` is emitted in 100 ns ticks. The same docs expose an `Animation` payload for SVG/blend-shape output. This PR accepts those source IDs/ticks directly and preserves raw animation payloads on normalized events for downstream inspection/future blend-shape support.

Source: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/how-to-speech-synthesis-viseme

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`

Fixes #141