### PR TITLE
[codex] document character onboarding and platform next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,14 @@ Open in LoomLarge: [Properties tab](https://www.characterloom.com/?drawer=open&t
 
 Before you tune AUs or hand-edit a profile, confirm that you picked the right preset and that the model actually matches it. Loom3 exposes a full preset-selection and validation workflow, not just low-level control APIs.
 
+The preflight loop is:
+
+1. Choose a candidate preset or profile.
+2. Lint the profile itself with `validateMappingConfig()`.
+3. Extract model facts with `extractModelData()` or `extractFromGLTF()`.
+4. Compare the model to the profile with `validateMappings()`, `isPresetCompatible()`, or `suggestBestPreset()`.
+5. Ask for best-effort fixes with `generateMappingCorrections()` or use `analyzeModel()` when you want the full report in one pass.
+
 ### Looking Up and Extending Presets by Type
 
 Use preset helpers when you want a stable entry point by model class instead of importing a preset constant directly:
@@ -413,6 +421,17 @@ const consistency = validateMappingConfig(resolved);
 console.log(consistency.errors, consistency.warnings);
 ```
 
+Use this when you are editing a profile by hand or applying saved profile data from a product UI. It catches structural mistakes such as missing semantic bone nodes, invalid composite rotation references, empty composite AU lists, duplicated AU directions, invalid continuum pairs, and mesh-category references that cannot be resolved from the profile itself.
+
+`validateMappingConfig()` returns a `MappingConsistencyResult`:
+
+| Field | Meaning |
+|-------|---------|
+| `valid` | `true` when there are no blocking internal config errors. |
+| `errors` | Blocking `MappingIssue[]` entries with `code`, `message`, `severity`, and optional `data`. |
+| `warnings` | Non-blocking `MappingIssue[]` entries that should be reviewed. |
+| `issues` | Combined `errors` and `warnings` in one list. |
+
 ### Checking a model against a preset
 
 ```typescript
@@ -436,6 +455,12 @@ const corrections = generateMappingCorrections(meshes, skeleton, resolved, {
 });
 ```
 
+`validateMappings()` compares a profile against the actual model assets. It reports found, missing, and unmapped morphs, bones, and meshes; computes a 0-100 compatibility `score`; and can include correction suggestions when `suggestCorrections` is enabled.
+
+`isPresetCompatible()` is the quick yes/no wrapper around `validateMappings()`. It currently returns `true` when the validation score is at least `50`. Use it for coarse preset filtering, not final authoring decisions.
+
+`generateMappingCorrections()` is a best-effort fuzzy matching helper. It returns a `correctedConfig`, `corrections`, and `unresolved` entries. Each correction records its `type`, `source`, `target`, `confidence`, `reason`, whether it was `applied`, and optional `auId` or `key`. Use `minConfidence` to tune how aggressive suggestions should be, and `useResolvedNames` when the model's actual names should replace prefix/suffix-derived names in the corrected profile.
+
 ### Suggesting the best preset from a candidate set
 
 ```typescript
@@ -450,6 +475,8 @@ const best = suggestBestPreset(meshes, skeleton, [
   BETTA_FISH_PRESET,
 ]);
 ```
+
+`suggestBestPreset()` runs `validateMappings()` for each candidate and returns `{ preset, score }` for the highest-scoring match, or `null` if the candidate list is empty. Treat the returned `score` as a starting point: a best match can still be too incomplete for production if important bones, visemes, or face meshes are missing.
 
 ### Running a full model analysis
 
@@ -471,6 +498,18 @@ const report = await analyzeModel({
 
 console.log(report.summary, report.overallScore);
 ```
+
+`extractModelData()` and `extractFromGLTF()` produce the same `ModelData` shape:
+
+| Field | Meaning |
+|-------|---------|
+| `bones` | Bone hierarchy entries with names, parents, children, world positions, and depth. |
+| `morphs` | Morph targets with name, mesh name, and morph index. |
+| `meshes` | Mesh records with name, `hasMorphTargets`, and `morphCount`. |
+| `animations` | Clip summaries with duration, tracks, animated bones, and animated morphs. |
+| `boneNames`, `morphNames`, `meshNames` | Quick lookup lists for tooling and UI filters. |
+
+`analyzeModel()` wraps extraction, optional preset validation, animation analysis, scoring, and summary generation. Use it for product onboarding, upload checks, and debug reports where a human-readable answer is more useful than separate low-level helper calls.
 
 Use this section when you need to:
 - choose between built-in presets before wiring the character into your app
@@ -569,7 +608,9 @@ import {
   extractFromGLTF,
   extractModelData,
   analyzeModel,
+  validateMappingConfig,
   validateMappings,
+  isPresetCompatible,
   generateMappingCorrections,
   getPreset,
 } from '@lovelace_lol/loom3';
@@ -584,18 +625,28 @@ const analysis = await analyzeModel({
   suggestCorrections: true,
 });
 
+const consistency = validateMappingConfig(preset);
+
 // Validate against lower-level mesh + skeleton inputs when you already have them
 const validation = validateMappings(meshes, skeleton, preset, { suggestCorrections: true });
+const compatible = isPresetCompatible(meshes, skeleton, preset);
 const corrections = generateMappingCorrections(meshes, skeleton, preset, { useResolvedNames: true });
+
+console.log(consistency.valid, compatible, validation.score, corrections.corrections.length);
 ```
 
 If you already have a `ModelData` bundle, `analyzeModel()` is the higher-level path; `validateMappings()` and `generateMappingCorrections()` are intentionally lower-level mesh/skeleton helpers.
 
 Use these helpers to:
 - Extract raw model facts with `extractModelData(model, meshes?, animations?)` or `extractFromGLTF(gltf)`
+- Lint the profile without model data with `validateMappingConfig(profile)`
 - Validate a preset against mesh/skeleton data with `validateMappings(meshes, skeleton, preset, options)`
+- Run a quick 50%-score compatibility check with `isPresetCompatible(meshes, skeleton, preset)`
+- Pick the highest-scoring preset from candidates with `suggestBestPreset(meshes, skeleton, presets)`
 - Generate best-effort fixes with `generateMappingCorrections(meshes, skeleton, preset, options)`
 - Run a single end-to-end pass with `analyzeModel({ source, preset, suggestCorrections })`
+
+`validateMappingConfig()` returns a `MappingConsistencyResult` with `valid`, `errors`, `warnings`, and combined `issues`.
 
 `validateMappings()` returns a `ValidationResult` with:
 - `valid` and `score`
@@ -603,6 +654,10 @@ Use these helpers to:
 - `missingMeshes`, `foundMeshes`, `unmappedMorphs`, `unmappedBones`, `unmappedMeshes`
 - `warnings`
 - optional `suggestedConfig`, `corrections`, and `unresolved` when suggestion mode is enabled
+
+`isPresetCompatible()` returns `true` when the validation score is at least `50`.
+
+`suggestBestPreset()` returns `{ preset, score }` for the highest-scoring candidate, or `null` when no candidates are provided.
 
 `generateMappingCorrections()` returns:
 - `correctedConfig`

--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ Loom3 is broader than a face-controller wrapper. The library spans four practica
 - Inspection and validation: mesh, morph, and bone discovery; preset-fit checks; correction suggestions; and full model analysis.
 - Runtime tooling: mesh/material debugging, mixer animation clip helpers, hair physics, and region/geometry helpers for annotation or camera tooling.
 
+The inspection and validation layer is what makes the rest of the system scalable. A product such as LoomLarge can upload an unknown GLB, inventory its bones and morph targets, choose the closest preset, explain what is missing, propose corrections, and save a reusable character profile. Once that profile exists, app code and AI agents can drive the character through semantic controls like AUs, visemes, gaze, head motion, and expression clips instead of hard-coding rig-specific morph names.
+
 ## Reading Paths
 
 Use the README in one of these paths:
 - First successful character: [Installation & Setup](#1-installation--setup) -> [Using Presets](#2-using-presets) -> [Preset Selection & Validation](#3-preset-selection--validation) -> [Getting to Know Your Character](#4-getting-to-know-your-character) -> [Action Unit Control](#7-action-unit-control) -> [Viseme System](#12-viseme-system) -> [Transition System](#13-transition-system) -> [Baked Animations](#16-baked-animations)
+- Uploading or onboarding a new character: [Using Presets](#2-using-presets) -> [Preset Selection & Validation](#3-preset-selection--validation) -> [Getting to Know Your Character](#4-getting-to-know-your-character) -> [Extending & Custom Presets](#5-extending--custom-presets) -> [API Reference](#18-api-reference)
 - Retargeting an existing rig: [Using Presets](#2-using-presets) -> [Preset Selection & Validation](#3-preset-selection--validation) -> [Getting to Know Your Character](#4-getting-to-know-your-character) -> [Extending & Custom Presets](#5-extending--custom-presets)
 - Skeletal-only character: [Creating Skeletal Animation Presets](#6-creating-skeletal-animation-presets) -> [Baked Animations](#16-baked-animations) -> [Regions & Geometry Helpers](#17-regions--geometry-helpers)
 - Annotation or camera tooling: [Preset Selection & Validation](#3-preset-selection--validation) -> [Getting to Know Your Character](#4-getting-to-know-your-character) -> [Regions & Geometry Helpers](#17-regions--geometry-helpers)
@@ -383,15 +386,94 @@ see [ANNOTATION_CONFIGURATION.md](./ANNOTATION_CONFIGURATION.md).
 
 Open in LoomLarge: [Properties tab](https://www.characterloom.com/?drawer=open&tab=properties) | [Mappings tab](https://www.characterloom.com/?drawer=open&tab=mappings) | [Bones tab](https://www.characterloom.com/?drawer=open&tab=bones)
 
-Before you tune AUs or hand-edit a profile, confirm that you picked the right preset and that the model actually matches it. Loom3 exposes a full preset-selection and validation workflow, not just low-level control APIs.
+This section is about the path from "I have a 3D character file" to "this character can be controlled semantically." The goal is not merely to list validation APIs. The goal is to make character rigging repeatable enough that a product UI, upload wizard, or LLM-assisted workflow can do most of the boring inspection work before a human starts tuning.
+
+Most character failures happen before animation code runs:
+
+- the model has morph targets, but their names do not match the selected preset
+- the model has useful bones, but the saved profile points at different bone names
+- visemes exist on a different mesh than the one the runtime is driving
+- the model is usable, but only after a small prefix, suffix, or naming correction
+- the model is not compatible, and the user needs to know that before spending time tuning
+
+Loom3's preflight APIs turn those unknowns into a profile decision. They help answer:
+
+- What does this GLB contain?
+- Which preset is the closest starting point?
+- What parts of the preset actually resolve on this model?
+- What should the product ask the user to fix?
+- What can be corrected automatically and saved back into the character profile?
+
+That matters for the bigger platform vision: once a character has a validated Loom3 profile, downstream code can ask for intent, not plumbing. A human, app workflow, or LLM can say "smile," "blink," "look left," "speak this phoneme," or "play this expression" through stable Loom3 controls while the profile translates that intent into the character's actual morphs, bones, meshes, visemes, and clips.
 
 The preflight loop is:
 
-1. Choose a candidate preset or profile.
-2. Lint the profile itself with `validateMappingConfig()`.
-3. Extract model facts with `extractModelData()` or `extractFromGLTF()`.
-4. Compare the model to the profile with `validateMappings()`, `isPresetCompatible()`, or `suggestBestPreset()`.
-5. Ask for best-effort fixes with `generateMappingCorrections()` or use `analyzeModel()` when you want the full report in one pass.
+1. Upload or load the GLB, then extract facts with `extractFromGLTF()` or `extractModelData()`.
+2. Use the extracted morph, bone, mesh, and animation inventory to show the user what the character can support.
+3. Pick a candidate preset with `getPreset()` or choose the strongest candidate with `suggestBestPreset()`.
+4. Lint the saved or edited profile with `validateMappingConfig()` so broken profile data does not enter the runtime.
+5. Compare the actual model to the profile with `validateMappings()` or the coarse `isPresetCompatible()` check.
+6. Use `generateMappingCorrections()` to propose safe renames and save a corrected profile when confidence is high enough.
+7. Use `analyzeModel()` when an upload wizard or debug report needs one summary object with model facts, preset fit, suggested corrections, animations, and a plain-language result.
+
+In practice, this lets users rig a character by progressively answering "what is in the file, what preset fits, what is missing, what can be corrected, and what profile should be saved" instead of manually reading every mesh, bone, and morph target name.
+
+### Character upload preflight
+
+This is the product-level shape these APIs are meant to support:
+
+```typescript
+import * as THREE from 'three';
+import {
+  BETTA_FISH_PRESET,
+  CC4_PRESET,
+  analyzeModel,
+  collectMorphMeshes,
+  extractFromGLTF,
+  generateMappingCorrections,
+  suggestBestPreset,
+  validateMappingConfig,
+  validateMappings,
+} from '@lovelace_lol/loom3';
+
+const modelData = extractFromGLTF(gltf);
+const meshes = collectMorphMeshes(gltf.scene);
+const skinnedMesh = gltf.scene.getObjectByProperty('type', 'SkinnedMesh') as THREE.SkinnedMesh | undefined;
+const skeleton = skinnedMesh?.skeleton ?? null;
+
+const best = suggestBestPreset(meshes, skeleton, [
+  CC4_PRESET,
+  BETTA_FISH_PRESET,
+]);
+
+const selectedProfile = best?.preset ?? CC4_PRESET;
+const corrections = generateMappingCorrections(meshes, skeleton, selectedProfile, {
+  minConfidence: 0.75,
+  useResolvedNames: true,
+});
+
+const profileToSave = corrections.correctedConfig;
+const consistency = validateMappingConfig(profileToSave);
+const validation = validateMappings(meshes, skeleton, profileToSave);
+
+const report = await analyzeModel({
+  source: { type: 'gltf', gltf },
+  preset: profileToSave,
+  suggestCorrections: true,
+});
+
+const uploadResult = {
+  modelData,
+  selectedPresetScore: best?.score ?? 0,
+  readyForRuntime: consistency.valid && validation.score >= 70,
+  warnings: [...validation.warnings, ...consistency.warnings.map((issue) => issue.message)],
+  unresolved: corrections.unresolved,
+  profileToSave,
+  summary: report.summary,
+};
+```
+
+In a character upload wizard, that result can drive the whole onboarding screen: show the detected morphs and bones, display a preset score, warn about missing face/eye/jaw controls, list unresolved mappings for the user to fix, and save the corrected profile when the match is good enough.
 
 ### Looking Up and Extending Presets by Type
 
@@ -408,6 +490,8 @@ const preset = getPreset('cc4');
 const extended = getPresetWithProfile('cc4', {
   morphToMesh: { face: ['Object_9'] },
 });
+
+const selectedProfile = extended;
 ```
 
 ### Validating the config itself
@@ -417,7 +501,7 @@ const extended = getPresetWithProfile('cc4', {
 ```typescript
 import { validateMappingConfig } from '@lovelace_lol/loom3';
 
-const consistency = validateMappingConfig(resolved);
+const consistency = validateMappingConfig(selectedProfile);
 console.log(consistency.errors, consistency.warnings);
 ```
 
@@ -445,12 +529,12 @@ import {
 const skinnedMesh = gltf.scene.getObjectByProperty('type', 'SkinnedMesh') as THREE.SkinnedMesh | undefined;
 const skeleton = skinnedMesh?.skeleton ?? null;
 
-const validation = validateMappings(meshes, skeleton, resolved, {
+const validation = validateMappings(meshes, skeleton, selectedProfile, {
   suggestCorrections: true,
 });
 
-const compatible = isPresetCompatible(meshes, skeleton, resolved);
-const corrections = generateMappingCorrections(meshes, skeleton, resolved, {
+const compatible = isPresetCompatible(meshes, skeleton, selectedProfile);
+const corrections = generateMappingCorrections(meshes, skeleton, selectedProfile, {
   useResolvedNames: true,
 });
 ```
@@ -492,7 +576,7 @@ const runtimeData = extractModelData(gltf.scene, meshes, gltf.animations);
 
 const report = await analyzeModel({
   source: { type: 'gltf', gltf },
-  preset: resolved,
+  preset: selectedProfile,
   suggestCorrections: true,
 });
 

--- a/VISION_AND_PRD.md
+++ b/VISION_AND_PRD.md
@@ -138,6 +138,95 @@ loom3 should own:
 
 That clarity is a feature, not a limitation.
 
+## Progress Snapshot, May 2026
+
+The project has moved from "facial control library" toward a real character-platform substrate. The important progress is not just the number of APIs added. The important progress is that the same profile is now becoming the contract between asset inspection, UI authoring, runtime playback, saved character identity, and AI-driven control.
+
+### What has materially improved
+
+- Profiles replaced older character-config thinking as the central shape for presets, overrides, annotations, visemes, mappings, and future saved behavior.
+- Loom3 now has stronger inspection and validation surfaces for uploaded models: model extraction, mapping linting, preset-fit scoring, correction suggestions, and unified model analysis.
+- Runtime control is broader and safer: profile-defined viseme bindings, jaw aggregation, mixer clip playback, inherited keyframe starts, runtime morph authoring, and hardened morph batch validation all make the engine more trustworthy for generated or user-authored animation data.
+- Annotation and camera behavior is moving into shared Loom3 helpers, which reduces LoomLarge-only math and makes semantic region behavior more portable.
+- LoomLarge has productized more of the studio loop: character picker onboarding, lazy upload wizard loading, pose capture, body morph authoring UI, saved emotes with emoji mappings, thumbnail capture/fallbacks, and loading-performance passes.
+- The agency/runtime direction is clearer. Latticework/Polyester work is becoming the behavioral agency layer around speech, blink, gaze, conversation, and runtime services, while Loom3 remains the expressive character engine and profile substrate.
+- The next architecture frontier is now explicit: renderer-neutral runtime contracts, a Three model-inspection adapter, a Three frame applier, a TypeScript runtime-core vertical slice, neutral clip descriptors, and a later package split that preserves `@lovelace_lol/loom3` compatibility.
+
+### What we have learned
+
+- The profile is the product contract. If a behavior cannot be inspected, previewed, saved, reloaded, and driven from the profile, it is still experimental glue.
+- Character onboarding has to start with preflight. Users should not need to know whether a GLB has the right morphs, bones, visemes, face mesh, jaw path, or eye controls before the product can tell them what is usable.
+- AI authoring needs bounded surfaces. LLMs should propose structured, previewable, minimal profile patches or generated morph candidates, not blindly rewrite whole character configs.
+- Expressions, emotes, poses, gestures, visemes, and authored morphs are converging on the same idea: reusable semantic behavior assets stored on or beside the character profile.
+- Runtime portability requires a cleaner core/adapter split, but that split should follow proven user-facing workflows. The core should be extracted around real paths like `setAU`, visemes, composite bones, clips, and morph authoring, not as an abstract package exercise first.
+- Performance is part of trust. Lazy loading, compositor loaders, thumbnail derivatives, compressed assets, and reduced frame churn are not polish work; they determine whether the product feels usable enough for creators to invest in profiles.
+
+## Where We Go Next
+
+The next phase should be sequenced around one product promise:
+
+> A user can upload or select a character, let the system inspect and repair the rig, save a durable profile, then direct that character through AI, UI controls, or code using semantic intent instead of rig internals.
+
+### 1. Finish character onboarding and preflight
+
+Make upload and first-run setup use the Loom3 inspection stack directly:
+
+- extract model facts with `extractFromGLTF()` / `extractModelData()`
+- choose or suggest a preset with `suggestBestPreset()`
+- lint and score the resulting profile with `validateMappingConfig()` and `validateMappings()`
+- generate safe corrections with `generateMappingCorrections()`
+- present missing controls and unresolved mappings in the UI before the user starts editing
+- save the corrected profile as the starting point for all later authoring
+
+This is the highest-leverage documentation and product story because it turns Loom3 from "a package with helpers" into the foundation of a guided character-rigging workflow.
+
+### 2. Promote saved expression work into reusable behavior assets
+
+LoomLarge's emote, pose, gesture, and animation work should converge instead of becoming separate drawers with separate persistence models:
+
+- promote saved emotes into the animation system so expressions can be found, previewed, reused, and triggered consistently
+- keep emoji mappings as a user-facing routing layer, not the only storage model
+- make AI-generated expression poses save as profile-backed behavior assets
+- keep poses and gestures profile-backed so body language becomes part of the character identity, not a transient scene state
+- document how AUs, visemes, poses, emotes, gestures, snippets, and mixer clips relate
+
+### 3. Turn authored morphs into a durable pipeline
+
+Runtime morph authoring is now real enough to build on, but the next step is durability and authoring:
+
+- define persisted authored-morph and morph-collection data that can survive reloads
+- validate mesh identity, vertex counts, topology hashes, payload size, and malformed deltas before profile mutation
+- support UI-created region/falloff morphs instead of raw JSON as the primary path
+- add AI-assisted morph generation only after the data model and validation path are safe
+- pursue GLB morph extraction and compressed base assets as the performance counterpart to authored morph persistence
+
+This is where "AI can help rig the character" becomes more than mapping names: it can help create new controllable deformations.
+
+### 4. Extract the renderer-neutral runtime core in vertical slices
+
+The architecture work should follow this order:
+
+1. Add benchmarks and parity fixtures so extraction is measurable.
+2. Define renderer-neutral runtime contracts and data IR.
+3. Extract `ThreeModelInspector` for binding manifests.
+4. Extract `ThreeFrameApplier` for morph and bone output synchronization.
+5. Move AU morph evaluation through a `TsRuntimeCore` vertical slice.
+6. Extend the core to visemes, jaw aggregation, continuum pairs, and composite bones.
+7. Split snippet and curve compilation into neutral clip descriptors plus Three clip construction.
+8. Only then plan the package split for core, Three, Fiber, Babylon, and compatibility exports.
+
+That sequence keeps current users safe while creating the path to Rust/Wasm, Babylon, Unity, and non-renderer tooling later.
+
+### 5. Clarify the three-layer offering
+
+The total offering is becoming three connected layers:
+
+- LoomLarge: the studio, upload wizard, authoring UI, preview/capture workflow, persistence, and user-facing product.
+- Loom3: the profile schema, preset library, inspection/preflight layer, semantic expressive engine, and renderer adapter path.
+- Polyester/Latticework: the behavioral agency layer for speech, blink, gaze, conversation, timing, and higher-level agent services.
+
+The documentation should consistently explain this split. Users should understand that LoomLarge is where they prepare and direct characters, Loom3 is what makes those characters semantically controllable and portable, and Polyester/Latticework is where autonomous behavior and multi-agency coordination can grow.
+
 ## PRD
 
 ## Product Goal


### PR DESCRIPTION
## What changed
- reframes the model inspection docs around the character onboarding problem: upload a GLB, inspect what is actually in it, choose a preset, validate fit, correct mapping names, and save a reusable profile
- adds a README reading path for uploading/onboarding a new character
- adds a character upload preflight example showing `extractFromGLTF`, `collectMorphMeshes`, `suggestBestPreset`, `generateMappingCorrections`, `validateMappingConfig`, `validateMappings`, and `analyzeModel` working together
- keeps the API-level return-shape documentation for `MappingConsistencyResult`, `ModelData`, `ValidationResult`, correction results, preset compatibility, and best-preset selection
- adds a May 2026 progress snapshot to `VISION_AND_PRD.md`, connecting recent Loom3, LoomLarge, and Polyester/Latticework progress to the larger character-platform direction
- adds a concrete next-step sequence: onboarding/preflight, profile-backed behavior assets, authored morph pipeline, runtime-core extraction, and clearer three-layer offering

## Why
The original update documented helper methods but did not explain the larger user workflow. These APIs matter because they let Loom3 and LoomLarge turn unknown character asset internals into a validated semantic profile. Once that profile exists, users and AI-driven workflows can control a character through expressive intent, such as AUs, visemes, gaze, head movement, emotes, poses, authored morphs, and expression clips, instead of manually wiring rig-specific morph and bone names.

The vision update also captures what the recent project work is teaching us: profiles are the product contract; preflight is the start of character rigging; AI authoring needs previewable, structured, minimal patches; and runtime portability should be extracted in vertical slices around proven workflows.

## Validation
- rebased onto current `origin/main` after Loom3 PR #160
- `git diff --check origin/main...HEAD`
- README/VISION docs-only change; package typecheck/tests not run because no code changed and this isolated worktree has no node_modules