### PR TITLE
Harden runtime morph authoring

### DIFF
--- a/RECENT_CHANGES.md
+++ b/RECENT_CHANGES.md
@@ -19,6 +19,7 @@
 
 ### Morph routing and docs
 - Morph targeting prefers `morphToMesh.face` when present and falls back to scanning meshes for morph keys.
+- Runtime morph authoring can register generated targets after load, with batch preflight and relative/absolute mode guards.
 - README terminology now uses `Loom3` as the primary name, with `@lovelace_lol/loom3` as the package import.
 - The docs now reflect the current viseme keys, preset extension helpers, and profile fields that the code actually exports.
 - Publish versions are computed by `.github/workflows/publish.yml` from the current npm version or release tag before `npm publish`; the committed `package.json` version is only the baseline used by that workflow.

--- a/src/engines/three/Loom3.morphAuthoring.test.ts
+++ b/src/engines/three/Loom3.morphAuthoring.test.ts
@@ -133,6 +133,54 @@ describe('Loom3 runtime morph target authoring', () => {
     expect(normalMorphs?.[1]?.array).toEqual(new Float32Array(9));
   });
 
+  it('rejects mixed relative and absolute morph targets on an existing morph geometry', () => {
+    const face = makeMesh('FaceMesh', { ExistingSmile: smileDelta });
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [face] });
+
+    expect(() => engine.addMorphTarget({
+      meshName: 'FaceMesh',
+      name: 'AbsoluteSmile',
+      position: bodyDelta,
+      relative: false,
+    }, { forceGeometryReplacement: false })).toThrow(/existing morph targets are relative/);
+    expect(face.geometry.morphTargetsRelative).toBe(true);
+    expect(face.morphTargetDictionary?.AbsoluteSmile).toBeUndefined();
+  });
+
+  it('prevalidates bulk morph targets before mutating any mesh', () => {
+    const face = makeMesh('FaceMesh');
+    const model = new Object3D();
+    model.add(face);
+
+    const engine = new Loom3({
+      presetType: 'cc4',
+      profile: { morphToMesh: { face: ['FaceMesh'] } },
+    });
+    engine.onReady({ model, meshes: [] });
+
+    expect(() => engine.addMorphTargets([
+      {
+        meshName: 'FaceMesh',
+        name: 'GoodMorph',
+        position: bodyDelta,
+      },
+      {
+        meshName: 'FaceMesh',
+        name: 'BadMorph',
+        position: new Float32Array([0, 1, 2]),
+      },
+    ])).toThrow(/expected 9/);
+    expect(face.morphTargetDictionary?.GoodMorph).toBeUndefined();
+    expect(face.geometry.morphAttributes.position).toBeUndefined();
+  });
+
   it('creates the first morph influence slot on a static mesh', async () => {
     const body = makeMesh('BodyMesh');
     const model = new Object3D();

--- a/src/engines/three/Loom3.ts
+++ b/src/engines/three/Loom3.ts
@@ -746,6 +746,7 @@ export class Loom3 implements LoomLarge {
   // ============================================================================
 
   addMorphTarget(target: MorphTargetDelta, options: AddMorphTargetOptions = {}): number {
+    this.validateMorphTargetDelta(target, options);
     const staleMorphTargets = this.collectResolvedExpressionMorphTargets();
     const index = this.applyMorphTargetDelta(target, options);
     this.refreshMorphTargets([target.meshName]);
@@ -754,16 +755,42 @@ export class Loom3 implements LoomLarge {
   }
 
   addMorphTargets(targets: MorphTargetDelta[], options: AddMorphTargetOptions = {}): Record<string, number> {
-    const staleMorphTargets = this.collectResolvedExpressionMorphTargets();
-    const result: Record<string, number> = {};
+    if (targets.length === 0) return {};
 
+    const batchKeys = new Set<string>();
+    const batchRelativeModeByMesh = new Map<string, boolean>();
     for (const target of targets) {
-      const index = this.applyMorphTargetDelta(target, options);
-      result[`${target.meshName}:${target.name}`] = index;
+      const key = `${target.meshName}:${target.name}`;
+      if (batchKeys.has(key)) {
+        throw new Error(`Morph target "${target.name}" for mesh "${target.meshName}" appears more than once in the same batch.`);
+      }
+      batchKeys.add(key);
+      this.validateMorphTargetDelta(target, options);
+      const targetIsRelative = target.relative !== false;
+      const batchRelativeMode = batchRelativeModeByMesh.get(target.meshName);
+      if (batchRelativeMode !== undefined && batchRelativeMode !== targetIsRelative) {
+        throw new Error(`Cannot mix relative and absolute morph targets for mesh "${target.meshName}" in the same batch.`);
+      }
+      batchRelativeModeByMesh.set(target.meshName, targetIsRelative);
     }
 
-    this.refreshMorphTargets(Array.from(new Set(targets.map((target) => target.meshName))));
-    this.reinitializeRuntimeStateFromCurrentControls(staleMorphTargets);
+    const staleMorphTargets = this.collectResolvedExpressionMorphTargets();
+    const result: Record<string, number> = {};
+    const touchedMeshes = new Set<string>();
+
+    try {
+      for (const target of targets) {
+        const index = this.applyMorphTargetDelta(target, options);
+        touchedMeshes.add(target.meshName);
+        result[`${target.meshName}:${target.name}`] = index;
+      }
+    } finally {
+      if (touchedMeshes.size > 0) {
+        this.refreshMorphTargets(Array.from(touchedMeshes));
+        this.reinitializeRuntimeStateFromCurrentControls(staleMorphTargets);
+      }
+    }
+
     return result;
   }
 
@@ -1652,6 +1679,34 @@ export class Loom3 implements LoomLarge {
     return this.getMorphValueByIndex(index);
   }
 
+  private validateMorphTargetDelta(target: MorphTargetDelta, options: AddMorphTargetOptions): void {
+    const mesh = this.requireNamedMesh(target.meshName);
+    const geometry = mesh.geometry;
+    const position = geometry.getAttribute('position');
+    if (!position) {
+      throw new Error(`Cannot add morph target "${target.name}" to mesh "${target.meshName}": geometry has no position attribute.`);
+    }
+    if (!target.name || !target.name.trim()) {
+      throw new Error(`Cannot add morph target to mesh "${target.meshName}": target name is required.`);
+    }
+
+    const existingIndex = this.getMeshMorphDictionary(mesh)[target.name];
+    if (existingIndex !== undefined && options.replace !== true) {
+      throw new Error(`Morph target "${target.name}" already exists on mesh "${target.meshName}". Pass replace: true to overwrite it.`);
+    }
+
+    this.assertMorphAttributeDataLength(target.name, 'position', target.position, position.itemSize, position.count);
+    const normal = geometry.getAttribute('normal');
+    if (target.normal) {
+      this.assertMorphAttributeDataLength(target.name, 'normal', target.normal, normal?.itemSize ?? 3, position.count);
+    }
+    const tangent = geometry.getAttribute('tangent');
+    if (target.tangent) {
+      this.assertMorphAttributeDataLength(target.name, 'tangent', target.tangent, tangent?.itemSize ?? 4, position.count);
+    }
+    this.assertCompatibleMorphTargetMode(geometry, target);
+  }
+
   private applyMorphTargetDelta(target: MorphTargetDelta, options: AddMorphTargetOptions): number {
     const mesh = this.requireNamedMesh(target.meshName);
     const sourceGeometry = mesh.geometry;
@@ -1673,6 +1728,7 @@ export class Loom3 implements LoomLarge {
     if (existingIndex !== undefined && !replace) {
       throw new Error(`Morph target "${target.name}" already exists on mesh "${target.meshName}". Pass replace: true to overwrite it.`);
     }
+    this.assertCompatibleMorphTargetMode(sourceGeometry, target);
 
     const geometry = forceGeometryReplacement ? sourceGeometry.clone() : sourceGeometry;
     const dictionary = { ...previousDictionary };
@@ -1771,6 +1827,36 @@ export class Loom3 implements LoomLarge {
     return dictionary;
   }
 
+  private assertMorphAttributeDataLength(
+    name: string,
+    semantic: string,
+    data: Float32Array | number[],
+    itemSize: number,
+    vertexCount: number
+  ): void {
+    const expectedLength = vertexCount * itemSize;
+    if (data.length !== expectedLength) {
+      throw new Error(
+        `Morph target "${name}" ${semantic} data has ${data.length} values; expected ${expectedLength} ` +
+        `(${vertexCount} vertices * itemSize ${itemSize}).`
+      );
+    }
+  }
+
+  private assertCompatibleMorphTargetMode(geometry: Mesh['geometry'], target: MorphTargetDelta): void {
+    const hasExistingMorphTargets = Object.values(geometry.morphAttributes).some((attributes) => (attributes?.length ?? 0) > 0);
+    if (!hasExistingMorphTargets) return;
+
+    const targetIsRelative = target.relative !== false;
+    if (geometry.morphTargetsRelative !== targetIsRelative) {
+      const existingMode = geometry.morphTargetsRelative ? 'relative' : 'absolute';
+      const targetMode = targetIsRelative ? 'relative' : 'absolute';
+      throw new Error(
+        `Cannot add ${targetMode} morph target "${target.name}" to mesh "${target.meshName}" because existing morph targets are ${existingMode}.`
+      );
+    }
+  }
+
   private setMorphAttributeAtIndex(
     geometry: Mesh['geometry'],
     semantic: string,
@@ -1780,14 +1866,9 @@ export class Loom3 implements LoomLarge {
     index: number,
     name: string
   ): void {
-    const expectedLength = vertexCount * itemSize;
-    if (data.length !== expectedLength) {
-      throw new Error(
-        `Morph target "${name}" ${semantic} data has ${data.length} values; expected ${expectedLength} ` +
-        `(${vertexCount} vertices * itemSize ${itemSize}).`
-      );
-    }
+    this.assertMorphAttributeDataLength(name, semantic, data, itemSize, vertexCount);
 
+    const expectedLength = vertexCount * itemSize;
     const attributes = geometry.morphAttributes[semantic] ? [...geometry.morphAttributes[semantic]] : [];
     while (attributes.length < index) {
       const empty = new BufferAttribute(new Float32Array(expectedLength), itemSize);


### PR DESCRIPTION
## Summary
- preflight runtime morph target batches before mutating meshes
- reject relative/absolute morph target mode mixing on existing morph geometries and within a batch
- refresh morph caches after any partially applied batch if an unexpected error occurs
- add regression coverage and a recent-changes note

## Context
This follows the architecture review for LoomLarge #619 and the merged runtime morph authoring work in #123. LoomLarge currently sends relative deltas, so this hardens the public Loom3 API before broader external or AI-authored morph payloads rely on it.

## Validation
- `npm ci`
- `npm test -- --run src/engines/three/Loom3.morphAuthoring.test.ts`
- `npm run typecheck`
